### PR TITLE
Fix/pin package versions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,6 +52,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.9'
+      - name: Show Python Version
+        run: which python && python --version
       - name: List
         run: pwd && ls -l
       - name: Setup Dependencies & Build and Package App

--- a/TA_CTIS_TAXII/package/lib/requirements.txt
+++ b/TA_CTIS_TAXII/package/lib/requirements.txt
@@ -7,11 +7,14 @@ typing-extensions==4.7.1
 # See: https://github.com/python-attrs/cattrs/pull/424
 cattrs==23.1.2
 attrs==24.2.0
-stix2
-stix2-patterns
+
+# Latest versions which supports Python 3.9
+stix2==3.0.1
+stix2-patterns==2.0.0
+
 splunktaucclib
 splunk-sdk
 solnlib
-taxii2-client
+taxii2-client==2.3.0
 pytz
 # remote-pdb


### PR DESCRIPTION
Make package job use Python 3.9, which is default version for Splunk 9.x - 10.1