### PR TITLE
Feature: user provided identity ID

### DIFF
--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.24.1+55f78f7",
+        "version": "1.24.1+28f942c",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.24.0+4e4c2e5",
+        "version": "1.24.1+55f78f7",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.24.1+04069c0",
+        "version": "1.24.1+79d1ee2",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.24.1+28f942c",
+        "version": "1.24.1+04069c0",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/abstract_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/abstract_collection.py
@@ -37,6 +37,11 @@ class AbstractKVStoreCollection(ABC, Generic[T]):
         pass
 
     @property
+    @abstractmethod
+    def primary_key(self) -> str:
+        pass
+
+    @property
     def collection(self) -> KVStoreCollectionData:
         return get_collection_data(collection_name=self.collection_name.value, session_key=self.session_key, app=self.app_namespace)
 
@@ -64,6 +69,10 @@ class AbstractKVStoreCollection(ABC, Generic[T]):
             logger.exception(f"Record does not exist or more than one record exists for query={query}")
             return False
 
+    def check_if_any_exists(self, primary_key_value: str) -> bool:
+        fetched = self.fetch_many_raw(query={self.primary_key: primary_key_value})
+        return len(fetched) > 0
+
     def fetch_exactly_one_structured(self, query: Dict) -> T:
         record = self.fetch_exactly_one_raw(query=query)
         structured = self.model_converter.structure(record, self.model_class)
@@ -86,6 +95,16 @@ class AbstractKVStoreCollection(ABC, Generic[T]):
         logger.info(f"Record before update: {record}")
         record_updated = attrs.evolve(record, **updates)
         return self.update_record(record=record_updated)
+
+    def insert_record(self, record: T) -> dict:
+        primary_key_value = getattr(record, self.primary_key)
+        assert primary_key_value is not None, f"Primary key of {self.primary_key} on {record} does not exist"
+        if self.check_if_any_exists(primary_key_value=primary_key_value):
+            raise ValueError(f"Record in collection={self.collection_name} with {self.primary_key}={primary_key_value} already exists.")
+        unstructured = self.model_converter.unstructure(record)
+        self.collection.insert(unstructured)
+        logger.info(f"Record inserted into collection={self.collection_name}: structured={record} unstructured={unstructured}")
+        return unstructured
 
     def update_record(self, record: T) -> T:
         record.set_modified_to_now()

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/groupings_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/groupings_collection.py
@@ -19,6 +19,10 @@ class GroupingsCollection(AbstractKVStoreCollection[GroupingModelV1]):
     def collection_name(self) -> CollectionName:
         return CollectionName.GROUPINGS
 
+    @property
+    def primary_key(self) -> str:
+        return GroupingsCollection.ID_FIELD
+
     def get_grouping(self, grouping_id: str) -> GroupingModelV1:
         return self.fetch_exactly_one_structured(query={GroupingsCollection.ID_FIELD: grouping_id})
 

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/identities_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/identities_collection.py
@@ -18,6 +18,10 @@ class IdentitiesCollection(AbstractKVStoreCollection[IdentityModelV1]):
     def collection_name(self) -> CollectionName:
         return CollectionName.IDENTITIES
 
+    @property
+    def primary_key(self) -> str:
+        return IdentitiesCollection.IDENTITY_ID_FIELD
+
     def get_identity(self, identity_id: str) -> IdentityModelV1:
         return self.fetch_exactly_one_structured(query={IdentitiesCollection.IDENTITY_ID_FIELD: identity_id})
 

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/indicators_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/indicators_collection.py
@@ -19,6 +19,10 @@ class IndicatorsCollection(AbstractKVStoreCollection[IndicatorModelV1]):
     def collection_name(self) -> CollectionName:
         return CollectionName.INDICATORS
 
+    @property
+    def primary_key(self) -> str:
+        return IndicatorsCollection.INDICATOR_ID_FIELD
+
     def fetch_many_by_grouping_id(self, grouping_id: str) -> List[IndicatorModelV1]:
         return self.fetch_many_structured(query={"grouping_id": grouping_id})
 

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/submissions_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/submissions_collection.py
@@ -5,6 +5,7 @@ from cattrs import Converter
 from typing import Type, Dict
 
 class SubmissionsCollection(AbstractKVStoreCollection[SubmissionModelV1]):
+    SUBMISSION_ID_FIELD = "submission_id"
     @property
     def model_class(self) -> Type[SubmissionModelV1]:
         return SubmissionModelV1
@@ -17,12 +18,16 @@ class SubmissionsCollection(AbstractKVStoreCollection[SubmissionModelV1]):
     def collection_name(self) -> CollectionName:
         return CollectionName.SUBMISSIONS
 
+    @property
+    def primary_key(self) -> str:
+        return SubmissionsCollection.SUBMISSION_ID_FIELD
+
     def get_submission(self, submission_id: str) -> SubmissionModelV1:
-        return self.fetch_exactly_one_structured(query={"submission_id": submission_id})
+        return self.fetch_exactly_one_structured(query={SubmissionsCollection.SUBMISSION_ID_FIELD: submission_id})
 
     def update_submission(self, submission_id: str, updates: Dict) -> SubmissionModelV1:
         """
         Update a submission by its ID with the provided update_data which is a dict of key-values.
         """
-        return self.update_one_structured(query={"submission_id": submission_id}, updates=updates)
+        return self.update_one_structured(query={SubmissionsCollection.SUBMISSION_ID_FIELD: submission_id}, updates=updates)
 

--- a/TA_CTIS_TAXII/package/bin/rest_create_identity.py
+++ b/TA_CTIS_TAXII/package/bin/rest_create_identity.py
@@ -9,7 +9,7 @@ logger.setLevel(logging.INFO)
 
 class CreateIdentityHandler(AbstractRestHandler):
     def handle(self, input_json: dict, query_params: dict, session_key: str) -> dict:
-        # TODO: Utility to nicely convert the ClassValidationError to a human-readable error message
+        # TODO: Add validation on identity_id that it should be lowercase
         try:
             identity = identity_converter.structure(input_json, IdentityModelV1)
         except Exception as exc:

--- a/TA_CTIS_TAXII/package/bin/rest_create_identity.py
+++ b/TA_CTIS_TAXII/package/bin/rest_create_identity.py
@@ -1,8 +1,6 @@
 import logging
 
-from solnlib._utils import get_collection_data
-
-from common import AbstractRestHandler, NAMESPACE
+from common import AbstractRestHandler
 from models import IdentityModelV1, identity_converter
 
 logger = logging.getLogger(__name__)
@@ -11,14 +9,6 @@ logger.setLevel(logging.INFO)
 
 class CreateIdentityHandler(AbstractRestHandler):
     def handle(self, input_json: dict, query_params: dict, session_key: str) -> dict:
-        collection = get_collection_data(collection_name="identities", session_key=session_key, app=NAMESPACE)
-        logger.info(f"Collection: {collection}")
-
-        """
-        TODO:
-        - Validation: Check if identity ID exists already. However, current use-case is to generate a new identity UUID
-        """
-
         # TODO: Utility to nicely convert the ClassValidationError to a human-readable error message
         try:
             identity = identity_converter.structure(input_json, IdentityModelV1)
@@ -26,12 +16,10 @@ class CreateIdentityHandler(AbstractRestHandler):
             logger.exception(f"Failed to convert input JSON to Identity Model")
             raise ValueError(repr(exc))
 
-        identity_dict = identity_converter.unstructure(identity)
-        logger.info(f"Inserting identity: {identity_dict}")
-        collection.insert(identity_dict)
+        self.kvstore_collections_context.identities.insert_record(identity)
 
         response = {
             "status" : "success",
-            "identity": identity_dict,
+            "identity": identity_converter.unstructure(identity),
         }
         return response

--- a/TA_CTIS_TAXII/test/test_model_identity_v1.py
+++ b/TA_CTIS_TAXII/test/test_model_identity_v1.py
@@ -39,6 +39,23 @@ def test_structure_identity():
     assert identity.tlp_v2_rating == TLPv2.AMBER
     assert identity.confidence == 1
 
+def test_structure_identity_with_provided_identity_id():
+    identity_id =  "identity--1f6ee067-1632-45d4-9ecb-d217475a81de"
+    as_dict = {
+        "name": "Org ABC",
+        "identity_id" : identity_id,
+        "identity_class": "organization",
+        "tlp_v2_rating": "TLP:AMBER",
+        "confidence" : 1,
+    }
+    identity = identity_converter.structure(as_dict, IdentityModelV1)
+    assert identity.name == "Org ABC"
+    assert identity.identity_id == identity_id
+    assert identity.identity_class == "organization"
+    assert identity.tlp_v2_rating == TLPv2.AMBER
+    assert identity.confidence == 1
+
+
 
 def test_to_stix():
     identity = IdentityModelV1(name="Org ABC", identity_class="organization", tlp_v2_rating=TLPv2.AMBER_STRICT,

--- a/integration_test/test_rest_api/conftest.py
+++ b/integration_test/test_rest_api/conftest.py
@@ -10,7 +10,8 @@ from util import clear_groupings_collection, clear_submissions_collection, clear
     create_indicator_form_payload, create_new_indicator, create_new_taxii_config, example_indicator, \
     new_sample_grouping, random_alnum_string, \
     delete_taxii_config
-from fixture_taxii_server import Taxii2ServerConnectionInfo, taxii2_server, taxii2_server_session, taxii2_server_is_reachable  # noqa: F401
+from taxii_server_connection_info import Taxii2ServerConnectionInfo
+from fixture_taxii_server import taxii2_server, taxii2_server_session, taxii2_server_is_reachable  # noqa: F401
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/integration_test/test_rest_api/fixture_taxii_server.py
+++ b/integration_test/test_rest_api/fixture_taxii_server.py
@@ -5,18 +5,14 @@ import pathlib
 import subprocess
 import tempfile
 import time
-from dataclasses import dataclass
 from util import random_alnum_string
+from taxii_server_connection_info import Taxii2ServerConnectionInfo
 
 import pytest
 import requests
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-MONGO_DB_PORT = os.environ.get('MONGO_DB_PORT', '27017')
-MONGO_DB_USERNAME = os.environ['MONGO_DB_USERNAME']
-MONGO_DB_PASSWORD = os.environ['MONGO_DB_PASSWORD']
 
 # This should be specified when running Splunk as Docker container
 TAXII_SERVER_HOST = os.environ.get('TAXII_SERVER_HOST', 'localhost')
@@ -32,13 +28,6 @@ MEDALLION_USERS_JSON = {
     }
 }
 
-MEDALLION_BACKEND_CONFIG = {
-  "backend": {
-    "module_class": "MongoBackend",
-    "uri": f"mongodb://{MONGO_DB_USERNAME}:{MONGO_DB_PASSWORD}@mongo:{MONGO_DB_PORT}/",
-    "filename": "medallion/test/data/default_data.json"
-  }
-}
 
 # TODO: Since we are now using a fork of the original cti-taxii-server repo, we can remove some of the overrides
 TAXII_SERVER_REPO = "https://github.com/bliew-splunk/cti-taxii-server.git"
@@ -53,28 +42,6 @@ services:
       AUTH_TYPE: basic
 """
 
-@dataclass
-class Taxii2ServerConnectionInfo:
-    server_url: str
-    username: str
-    password: str
-
-    @property
-    def server_discovery_url(self) -> str:
-        return f"{self.server_url}/taxii2"
-
-    @property
-    def default_api_root_url(self) -> str:
-        return f"{self.server_url}/trustgroup1"
-
-    @property
-    def readable_and_writable_collection_id(self) -> str:
-        return "365fed99-08fa-fdcd-a1b3-fb247eb41d01"
-
-    @property
-    def readable_and_writable_collection_url(self) -> str:
-        # https://github.com/oasis-open/cti-taxii-server/blob/39e76bf18be5371e9570de7e5f340c3937b69c0d/medallion/test/data/default_data.json#L106C24-L106C60
-        return f"{self.server_url}/trustgroup1/{self.readable_and_writable_collection_id}"
 
 def run_subprocess_and_log_output(cmd, **kwargs):
     logger.info(f"Running command: {cmd}")
@@ -88,6 +55,16 @@ def run_subprocess_and_log_output(cmd, **kwargs):
 
 @pytest.fixture(scope='module')
 def taxii2_server():
+    MONGO_DB_PORT = os.environ.get('MONGO_DB_PORT', '27017')
+    MONGO_DB_USERNAME = os.environ['MONGO_DB_USERNAME']
+    MONGO_DB_PASSWORD = os.environ['MONGO_DB_PASSWORD']
+    MEDALLION_BACKEND_CONFIG = {
+        "backend": {
+            "module_class": "MongoBackend",
+            "uri": f"mongodb://{MONGO_DB_USERNAME}:{MONGO_DB_PASSWORD}@mongo:{MONGO_DB_PORT}/",
+            "filename": "medallion/test/data/default_data.json"
+        }
+    }
     with tempfile.TemporaryDirectory() as tmpdirname:
         logger.info(f'Created temporary directory: {tmpdirname}')
         run_subprocess_and_log_output(["git", "clone", "--depth=1", TAXII_SERVER_REPO, tmpdirname])

--- a/integration_test/test_rest_api/taxii_server_connection_info.py
+++ b/integration_test/test_rest_api/taxii_server_connection_info.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+@dataclass
+class Taxii2ServerConnectionInfo:
+    server_url: str
+    username: str
+    password: str
+
+    @property
+    def server_discovery_url(self) -> str:
+        return f"{self.server_url}/taxii2"
+
+    @property
+    def default_api_root_url(self) -> str:
+        return f"{self.server_url}/trustgroup1"
+
+    @property
+    def readable_and_writable_collection_id(self) -> str:
+        return "365fed99-08fa-fdcd-a1b3-fb247eb41d01"
+
+    @property
+    def readable_and_writable_collection_url(self) -> str:
+        # https://github.com/oasis-open/cti-taxii-server/blob/39e76bf18be5371e9570de7e5f340c3937b69c0d/medallion/test/data/default_data.json#L106C24-L106C60
+        return f"{self.server_url}/trustgroup1/{self.readable_and_writable_collection_id}"

--- a/integration_test/test_rest_api/test_identities_api.py
+++ b/integration_test/test_rest_api/test_identities_api.py
@@ -1,3 +1,6 @@
+import pytest
+import requests
+
 from util import create_new_identity, get_identities_collection, list_identities, edit_identity, delete_identity
 
 
@@ -21,6 +24,44 @@ class TestScenarios:
         assert identity["confidence"] == 50
         assert identity["tlp_v2_rating"] == "TLP:GREEN"
         assert "identity_id" in identity
+
+    def test_add_new_identity_with_specified_id(self, session, cleanup_identities_collection):
+        user_specified_id =  "identity--ef308599-d00f-4bba-adc1-530d9267fe77"
+        create_new_identity(session, {"name": "test_identity",
+                                                 "identity_class": "organization",
+                                                 "identity_id": user_specified_id,
+                                                 "confidence": 50,
+                                                 "tlp_v2_rating": "TLP:GREEN"})
+
+        resp = list_identities(session, skip=0, limit=0, query={"identity_id": user_specified_id})
+        assert resp["total"] == 1
+        assert len(resp["records"]) == 1
+
+        only_record = resp["records"][0]
+        assert only_record["name"] == "test_identity"
+        assert only_record["identity_id"] == user_specified_id
+
+    def test_should_not_overwrite_existing_identity(self, session, cleanup_identities_collection):
+        user_specified_id = "identity--dfba407a-655d-4fb6-9c3e-ecc933186df2"
+        create_new_identity(session, {"name": "test_identity",
+                                      "identity_class": "organization",
+                                      "identity_id": user_specified_id,
+                                      "confidence": 50,
+                                      "tlp_v2_rating": "TLP:GREEN"})
+        resp = list_identities(session, skip=0, limit=0, query={"identity_id": user_specified_id})
+        assert resp["total"] == 1
+        assert len(resp["records"]) == 1
+
+        # should throw a Client error because record with identity_id already exists.
+        with pytest.raises(requests.HTTPError) as excinfo:
+            create_new_identity(session, {"name": "test_identity",
+                                          "identity_class": "organization",
+                                          "identity_id": user_specified_id,
+                                          "confidence": 50,
+                                          "tlp_v2_rating": "TLP:GREEN"})
+        assert excinfo.value.response.status_code == 400
+        assert 'already exists' in str(excinfo.value.response.content)
+
 
     def test_query_identities(self, session, cleanup_identities_collection):
         create_new_identity_with_defaults(session, name="org1", identity_class="organization")

--- a/splunkui/packages/my-page/src/ActionModal.jsx
+++ b/splunkui/packages/my-page/src/ActionModal.jsx
@@ -17,7 +17,7 @@ export default function ActionModal({
                                         endpointFunction,
                                         endpointFunctionArgs,
                                         modalBodyContent,
-                                        actionSuccessUrl,
+                                        actionSuccessUrl = null,
                                     }) {
     const [loading, setLoading] = useState(false);
     const ActionButton = actionButtonComponent;
@@ -30,7 +30,11 @@ export default function ActionModal({
                 setLoading(false);
                 onRequestClose();
                 // Refresh the page or redirect to a new page
-                window.location = actionSuccessUrl ?? window.location;
+                if(actionSuccessUrl){
+                    window.location = actionSuccessUrl;
+                }else{
+                    window.location.reload();
+                }
             },
             errorHandler: (e) => {
                 console.error(e);

--- a/splunkui/packages/my-page/src/CancelSubmissionModal.jsx
+++ b/splunkui/packages/my-page/src/CancelSubmissionModal.jsx
@@ -1,7 +1,7 @@
+import React from "react";
+import P from "@splunk/react-ui/Paragraph";
 import ActionModal from "./ActionModal";
 import {cancelSubmission} from "./ApiClient";
-import P from "@splunk/react-ui/Paragraph";
-import React from "react";
 import {CancelSubmissionButton} from "./buttons/CancelSubmissionButton";
 
 export function CancelSubmissionModal({open, onRequestClose, submission}) {

--- a/splunkui/packages/my-page/src/DeleteModal.jsx
+++ b/splunkui/packages/my-page/src/DeleteModal.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import DeleteButton from "./DeleteButton";
 import P from "@splunk/react-ui/Paragraph";
+import DeleteButton from "./DeleteButton";
 import {deleteGrouping, deleteIndicator} from "./ApiClient";
 import {VIEW_GROUPINGS_PAGE, VIEW_INDICATORS_PAGE} from "./urls";
 import ActionModal from "./ActionModal";

--- a/splunkui/packages/my-splunk-app/src/main/webapp/common/IdentityForm.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/common/IdentityForm.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {FormProvider, useForm} from "react-hook-form";
 import SubmitButton from "@splunk/my-page/src/SubmitButton";
 import {editIdentity, getIdentity, postCreateIdentity, useGetRecord} from "@splunk/my-page/src/ApiClient";
@@ -12,6 +12,7 @@ import {CustomControlGroup} from "@splunk/my-page/src/CustomControlGroup";
 import {HorizontalButtonLayout} from "@splunk/my-page/src/HorizontalButtonLayout";
 import PropTypes from "prop-types";
 import {PageHeading, PageHeadingContainer} from "@splunk/my-page/src/PageHeading";
+import Switch from '@splunk/react-ui/Switch';
 import {IdentityClassField, IdentityIdField, NameField} from "./identity_form/fields";
 import {useOnFormSubmit} from "./formSubmit";
 import {usePageTitle} from "./utils";
@@ -41,18 +42,45 @@ function GotoIdentitiesPageButton() {
     return (<Button to={VIEW_IDENTITIES_PAGE} appearance="primary" label="Go to Identities"/>);
 }
 
+function RenderIdentityIdField({ hasExistingIdentity, shouldAutogenerateId }) {
+    if (hasExistingIdentity) {
+        return <IdentityIdField disabled fieldName={FORM_FIELD_IDENTITY_ID} />;
+    }
+    if (!shouldAutogenerateId) {
+        return <IdentityIdField fieldName={FORM_FIELD_IDENTITY_ID} />;
+    }
+    return null;
+}
+
+RenderIdentityIdField.propTypes = {
+    hasExistingIdentity: PropTypes.bool,
+    shouldAutogenerateId: PropTypes.bool,
+}
+
+function validateIdentityId(value){
+    if(!String(value).startsWith("identity--")){
+        return "Should start with 'identity--'";
+    }
+    const regex = /^identity--[a-zA-Z0-9-]{36}$/;
+    if(!regex.test(value)){
+        return "Should be in format of 'identity--{UUIDv4}'";
+    }
+    return null;
+}
+
 export function Form({existingIdentity}) {
     const title = existingIdentity ? "Edit Identity" : "Create New Identity";
     usePageTitle(title);
 
     const submissionSuccessModalTitle = existingIdentity ? "Successfully Edited Identity" : "Successfully Created New Identity";
+    const [autogenerateId, setAutogenerateId] = useState(true);
     const methods = useForm({
         mode: 'all',
         defaultValues: {
             [FIELD_CONFIDENCE]: 100,
         }
     });
-    const {register, setValue, handleSubmit, formState} = methods;
+    const {register, unregister, setValue, handleSubmit, formState} = methods;
 
     register(FORM_FIELD_NAME, {required: "Name is required.", value: ""});
     register(FORM_FIELD_IDENTITY_CLASS, {required: "Identity Class is required.", value: ""});
@@ -73,6 +101,20 @@ export function Form({existingIdentity}) {
         }
     }, [existingIdentity, setValue]);
 
+    useEffect(() => {
+        if(!existingIdentity) {
+            if (!autogenerateId) {
+                register(FORM_FIELD_IDENTITY_ID, {
+                    required: 'Identity ID is required.',
+                    value: '',
+                    validate: validateIdentityId,
+                });
+            } else {
+                unregister(FORM_FIELD_IDENTITY_ID);
+            }
+        }
+    }, [autogenerateId, existingIdentity, register, unregister]);
+
     const postEndpointFunction = existingIdentity ? editIdentity : postCreateIdentity;
     const {submitSuccess, submissionError, onSubmit, submitButtonDisabled} = useOnFormSubmit({
         formMethods: methods,
@@ -87,36 +129,61 @@ export function Form({existingIdentity}) {
         <FormProvider {...methods}>
             <MyForm onSubmit={handleSubmit(onSubmit)}>
                 <PageHeadingContainer>
-                    <PageHeading>{title}</PageHeading>
+                    <PageHeading level={2}>{title}</PageHeading>
                 </PageHeadingContainer>
                 <section>
-                    {submissionError && <Message appearance="fill" type="error">
-                        {submissionError?.json?.error && <code>{submissionError.json.error}</code>}
-                        {submissionError?.error && <code>{submissionError.error.toString()}</code>}
-                    </Message>}
-                    {existingIdentity && <IdentityIdField disabled fieldName={FORM_FIELD_IDENTITY_ID}/>}
-                    <NameField fieldName={FORM_FIELD_NAME}/>
-                    <IdentityClassField fieldName={FORM_FIELD_IDENTITY_CLASS} options={IDENTITY_CLASSES}/>
-                    <TLPv2RatingField fieldName={FORM_FIELD_TLP_V2_RATING}/>
-                    <ConfidenceField fieldName={FIELD_CONFIDENCE}/>
+                    {submissionError && (
+                        <Message appearance="fill" type="error">
+                            {submissionError?.json?.error && (
+                                <code>{submissionError.json.error}</code>
+                            )}
+                            {submissionError?.error && (
+                                <code>{submissionError.error.toString()}</code>
+                            )}
+                        </Message>
+                    )}
+                    {!existingIdentity && (
+                        <CustomControlGroup>
+                            <Switch
+                                appearance="toggle"
+                                selected={autogenerateId}
+                                onClick={() => setAutogenerateId(!autogenerateId)}
+                            >
+                                Auto-generate ID
+                            </Switch>
+                        </CustomControlGroup>
+                    )}
+                    <RenderIdentityIdField
+                        hasExistingIdentity={!!existingIdentity}
+                        shouldAutogenerateId={autogenerateId}
+                    />
+                    <NameField fieldName={FORM_FIELD_NAME} />
+                    <IdentityClassField
+                        fieldName={FORM_FIELD_IDENTITY_CLASS}
+                        options={IDENTITY_CLASSES}
+                    />
+                    <TLPv2RatingField fieldName={FORM_FIELD_TLP_V2_RATING} />
+                    <ConfidenceField fieldName={FIELD_CONFIDENCE} />
                     <CustomControlGroup>
                         <HorizontalButtonLayout>
-                            <SubmitButton inline disabled={submitButtonDisabled} submitting={formState.isSubmitting}
-                                          label={existingIdentity ? "Edit Identity" : "Create Identity"}/>
+                            <SubmitButton
+                                inline
+                                disabled={submitButtonDisabled}
+                                submitting={formState.isSubmitting}
+                                label={existingIdentity ? 'Edit Identity' : 'Create Identity'}
+                            />
                         </HorizontalButtonLayout>
                     </CustomControlGroup>
                 </section>
                 <Modal open={submitSuccess}>
-                    <Modal.Header
-                        title={submissionSuccessModalTitle}
-                    />
+                    <Modal.Header title={submissionSuccessModalTitle} />
                     <Modal.Body>
-                        <GotoIdentitiesPageButton/>
+                        <GotoIdentitiesPageButton />
                     </Modal.Body>
                 </Modal>
             </MyForm>
         </FormProvider>
-    )
+    );
 }
 
 Form.propTypes = {

--- a/splunkui/packages/my-splunk-app/src/main/webapp/common/IdentityForm.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/common/IdentityForm.jsx
@@ -61,11 +61,29 @@ function validateIdentityId(value){
     if(!String(value).startsWith("identity--")){
         return "Should start with 'identity--'";
     }
-    const regex = /^identity--[a-zA-Z0-9-]{36}$/;
+    const regex = /^identity--[a-f0-9-]{36}$/;
     if(!regex.test(value)){
-        return "Should be in format of 'identity--{UUIDv4}'";
+        return "Should be in format of 'identity--{UUIDv4}'. Lowercase only.";
     }
     return null;
+}
+
+function SwitchForShouldAutogenerateId({autogenerateId, setAutogenerateId}){
+    return (
+        <CustomControlGroup>
+            <Switch
+                appearance="toggle"
+                selected={autogenerateId}
+                onClick={() => setAutogenerateId(!autogenerateId)}
+            >
+                Auto-generate ID
+            </Switch>
+        </CustomControlGroup>
+    );
+}
+SwitchForShouldAutogenerateId.propTypes = {
+    autogenerateId: PropTypes.string,
+    setAutogenerateId: PropTypes.func,
 }
 
 export function Form({existingIdentity}) {
@@ -142,17 +160,7 @@ export function Form({existingIdentity}) {
                             )}
                         </Message>
                     )}
-                    {!existingIdentity && (
-                        <CustomControlGroup>
-                            <Switch
-                                appearance="toggle"
-                                selected={autogenerateId}
-                                onClick={() => setAutogenerateId(!autogenerateId)}
-                            >
-                                Auto-generate ID
-                            </Switch>
-                        </CustomControlGroup>
-                    )}
+                    {!existingIdentity && <SwitchForShouldAutogenerateId autogenerateId={autogenerateId} setAutogenerateId={setAutogenerateId}/>}
                     <RenderIdentityIdField
                         hasExistingIdentity={!!existingIdentity}
                         shouldAutogenerateId={autogenerateId}


### PR DESCRIPTION
Resolves #64 

# Behaviour Summary

## New Identity Form
- Switch toggle which by default will tell backend to autogenerate the ID. If switch is disabled then a form input will show to allow user input of `identity_id`.
- There is frontend validation of identity_id as per the regex in `IdentityForm.jsx`. Lowercase only is expected, with a format of `identity--{UUIDv4}`. Backend validation is already done via the stix2 library. Lowercase not enforced on backend.
- REST endpoint `rest_create_identity.py`: uniqueness is enforced on the identity_id for the collection. Note that this is case sensitive, which is why lowercase was enforced.

## Edit Identity Form
- identity_id cannot be modified for a given Identity record. This is the same behaviour as previously.

# Notes
- Backend collection classes now have a `primary_key` which enforces record uniqueness on a given field. Currently only `AbstractKVStoreCollection.insert_record(record)` uses this primary key.
