### PR TITLE
Performance: Optimise load indicators on view groupings page

### DIFF
--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.24.1+79d1ee2",
+        "version": "1.25.0+ffeb289",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.25.0+1c98423",
+        "version": "1.25.0+3507d77",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.25.0+ce008b0",
+        "version": "1.25.0+65e2b7a",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.25.0+ffeb289",
+        "version": "1.25.0+ce008b0",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.25.0+3507d77",
+        "version": "1.25.0+3331b03",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.25.0+65e2b7a",
+        "version": "1.25.0+1c98423",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.25.0+3331b03",
+        "version": "1.25.0+52404b1",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/abstract_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/abstract_collection.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from typing import Dict, Generic, List, Optional, Type, TypeVar
+import json
 
 from cattrs import Converter
 import attrs
@@ -56,10 +57,15 @@ class AbstractKVStoreCollection(ABC, Generic[T]):
         Return the _key of the deleted record.
         """
         record = self.fetch_exactly_one_structured(query=query)
+        # https://github.com/splunk/splunk-sdk-python/blob/2.1.1/splunklib/client.py#L4077
         delete_http_resp = self.collection.delete_by_id(id=record.key)
 
         logger.info(f"Deleted record with _key: {record.key}, response: {delete_http_resp}")
         return record.key
+
+    def delete_many(self, query: Dict):
+        delete_http_resp = self.collection.delete(query=json.dumps(query))
+        return str(delete_http_resp)
 
     def check_if_exactly_one_exists(self, query: Dict) -> bool:
         try:

--- a/TA_CTIS_TAXII/package/bin/rest_delete_indicator.py
+++ b/TA_CTIS_TAXII/package/bin/rest_delete_indicator.py
@@ -3,11 +3,17 @@ from common import AbstractRestHandler
 
 class DeleteIndicatorHandler(AbstractRestHandler):
     def handle(self, input_json: dict, query_params: dict, session_key: str) -> dict:
-        indicator_id = input_json["indicator_id"]
-        indicator = self.kvstore_collections_context.indicators.get_indicator(indicator_id=indicator_id)
+        payload_indicator_id = input_json["indicator_id"]
+        assert isinstance(payload_indicator_id, str) or isinstance(payload_indicator_id, list), "Expected indicator_id to be either a string or an array of strings"
 
-        self.kvstore_collections_context.indicators.delete_indicator(indicator_id=indicator_id)
+        if isinstance(payload_indicator_id, str):
+            indicator_ids = [payload_indicator_id]
+        else:
+            indicator_ids = payload_indicator_id
 
-        self.update_grouping_tlp_rating_to_match_indicators(grouping_id=indicator.grouping_id)
+        for indicator_id in indicator_ids:
+            indicator = self.kvstore_collections_context.indicators.get_indicator(indicator_id=indicator_id)
+            self.kvstore_collections_context.indicators.delete_indicator(indicator_id=indicator_id)
+            self.update_grouping_tlp_rating_to_match_indicators(grouping_id=indicator.grouping_id)
 
         return {}

--- a/TA_CTIS_TAXII/package/bin/rest_delete_indicator.py
+++ b/TA_CTIS_TAXII/package/bin/rest_delete_indicator.py
@@ -1,8 +1,12 @@
 from common import AbstractRestHandler
 
-
 class DeleteIndicatorHandler(AbstractRestHandler):
     def handle(self, input_json: dict, query_params: dict, session_key: str) -> dict:
+        payload_grouping_id = input_json.get('grouping_id')
+        if payload_grouping_id is not None:
+            query = {"grouping_id": payload_grouping_id}
+            return {"response" : self.kvstore_collections_context.indicators.delete_many(query=query)}
+
         payload_indicator_id = input_json["indicator_id"]
         assert isinstance(payload_indicator_id, str) or isinstance(payload_indicator_id, list), "Expected indicator_id to be either a string or an array of strings"
 

--- a/integration_test/test_rest_api/test_indicators_api.py
+++ b/integration_test/test_rest_api/test_indicators_api.py
@@ -1,4 +1,5 @@
 from .util import bulk_insert_indicators, create_indicator_form_payload, create_new_indicator, delete_indicator, \
+    delete_indicators, \
     edit_indicator, example_indicator, get_groupings_collection, get_identities_collection, get_indicators_collection, \
     list_indicators, new_indicator_payload, new_sample_grouping, get_grouping
 
@@ -130,6 +131,28 @@ class TestScenarios:
         indicators_2 = list_indicators(session, skip=0, limit=100)
         assert len(indicators_2["records"]) == 0
         assert indicators_2["total"] == 0
+
+    def test_delete_multiple_indicators(self, session, cleanup_all_collections):
+        assert_collections_are_empty(session)
+        payload = create_indicator_form_payload(grouping_id=new_sample_grouping(session)["grouping_id"],
+                                                indicators=[example_indicator()])
+        create_new_indicator(session, payload=payload)
+        create_new_indicator(session, payload=payload)
+        create_new_indicator(session, payload=payload)
+
+        indicators = get_indicators_collection(session)
+        assert len(indicators) == 3
+        indicator1 = indicators[0]
+        indicator2 = indicators[1]
+        indicator3 = indicators[2]
+
+        # We delete 2 of the 3 indicators
+        delete_indicators(session, indicator_ids=[indicator1["indicator_id"], indicator2["indicator_id"]])
+        indicators_2 = list_indicators(session, skip=0, limit=100)
+        assert len(indicators_2["records"]) == 1
+        assert indicators_2["total"] == 1
+        # Check that the last remaining is indeed indicator3
+        assert indicators_2["records"][0]["indicator_id"] == indicator3["indicator_id"]
 
     def test_grouping_should_update_tlp_rating_when_indicators_are_edited_or_deleted(self, session, cleanup_all_collections):
         grouping = new_sample_grouping(session)

--- a/integration_test/test_rest_api/test_indicators_api.py
+++ b/integration_test/test_rest_api/test_indicators_api.py
@@ -1,5 +1,5 @@
 from .util import bulk_insert_indicators, create_indicator_form_payload, create_new_indicator, delete_indicator, \
-    delete_indicators, \
+    delete_indicators, delete_indicators_by_grouping_id, \
     edit_indicator, example_indicator, get_groupings_collection, get_identities_collection, get_indicators_collection, \
     list_indicators, new_indicator_payload, new_sample_grouping, get_grouping
 
@@ -153,6 +153,29 @@ class TestScenarios:
         assert indicators_2["total"] == 1
         # Check that the last remaining is indeed indicator3
         assert indicators_2["records"][0]["indicator_id"] == indicator3["indicator_id"]
+
+    def test_delete_bulk_by_grouping_id(self, session, cleanup_all_collections):
+        assert_collections_are_empty(session)
+        grouping_id_1 = new_sample_grouping(session)["grouping_id"]
+        grouping_id_2 = new_sample_grouping(session)["grouping_id"]
+
+        payload_1 = create_indicator_form_payload(grouping_id=grouping_id_1, indicators=[example_indicator(), example_indicator()])
+        create_new_indicator(session, payload=payload_1)
+
+        payload_2 = create_indicator_form_payload(grouping_id=grouping_id_2, indicators=[example_indicator(), example_indicator()])
+        create_new_indicator(session, payload=payload_2)
+
+        indicators = list_indicators(session, skip=0, limit=0)
+        assert len(indicators["records"]) == 4
+
+        # delete all indicators belonging to grouping_id_1
+        delete_indicators_by_grouping_id(session, grouping_id=grouping_id_1)
+
+        indicators = list_indicators(session, skip=0, limit=0)
+        assert len(indicators["records"]) == 2
+        for indicator in indicators["records"]:
+            # We should be left with indicators in grouping_id_2 only
+            assert indicator["grouping_id"] == grouping_id_2
 
     def test_grouping_should_update_tlp_rating_when_indicators_are_edited_or_deleted(self, session, cleanup_all_collections):
         grouping = new_sample_grouping(session)

--- a/integration_test/test_rest_api/util.py
+++ b/integration_test/test_rest_api/util.py
@@ -4,7 +4,7 @@ import string
 import uuid
 import os
 import logging
-from typing import Optional
+from typing import Optional, List
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -148,6 +148,10 @@ def delete_grouping(session, grouping_id: str) -> dict:
         "grouping_id": grouping_id
     })
 
+def delete_indicators(session, indicator_ids: List[str]) -> dict:
+    return delete_endpoint(endpoint="delete-indicator", session=session, payload={
+        "indicator_id": indicator_ids
+    })
 def delete_indicator(session, indicator_id: str) -> dict:
     return delete_endpoint(endpoint="delete-indicator", session=session, payload={
         "indicator_id": indicator_id

--- a/integration_test/test_rest_api/util.py
+++ b/integration_test/test_rest_api/util.py
@@ -148,6 +148,11 @@ def delete_grouping(session, grouping_id: str) -> dict:
         "grouping_id": grouping_id
     })
 
+def delete_indicators_by_grouping_id(session, grouping_id: str) -> dict:
+    return delete_endpoint(endpoint="delete-indicator", session=session, payload={
+        "grouping_id": grouping_id
+    })
+
 def delete_indicators(session, indicator_ids: List[str]) -> dict:
     return delete_endpoint(endpoint="delete-indicator", session=session, payload={
         "indicator_id": indicator_ids
@@ -167,7 +172,7 @@ def query_collection_endpoint(endpoint:str, session, skip:int, limit:int, query:
     return resp.json()
 
 
-def list_indicators(session, skip: int, limit: int, query: dict = None) -> dict:
+def list_indicators(session, skip: int=0, limit: int=0, query: dict = None) -> dict:
     return query_collection_endpoint(endpoint="list-indicators", session=session, skip=skip, limit=limit, query=query)
 
 def list_identities(session, skip: int, limit: int, query: dict = None) -> dict:

--- a/splunkui/packages/my-page/src/ApiClient.js
+++ b/splunkui/packages/my-page/src/ApiClient.js
@@ -151,6 +151,15 @@ export function deleteIndicator({indicatorId, successHandler, errorHandler}) {
         errorHandler
     })
 }
+export function deleteIndicatorsInGrouping({ groupingId, successHandler, errorHandler }) {
+    console.log('Deleting indicators in grouping:', groupingId);
+    return deleteData({
+        endpoint: 'delete-indicator',
+        data: { grouping_id: groupingId },
+        successHandler,
+        errorHandler,
+    });
+}
 
 export function cancelSubmission({submissionId, successHandler, errorHandler}) {
     console.log('Cancelling submission:', submissionId);

--- a/splunkui/packages/my-page/src/IndicatorCard.jsx
+++ b/splunkui/packages/my-page/src/IndicatorCard.jsx
@@ -1,53 +1,84 @@
 import React from 'react';
 import Card from '@splunk/react-ui/Card';
-import P from "@splunk/react-ui/Paragraph";
-import styled from "styled-components";
-import {variables} from "@splunk/themes";
-import PropTypes from "prop-types";
-import {getIndicator, useGetRecord} from "./ApiClient";
-import Loader from "./Loader";
-import {viewIndicator} from "./urls";
-import {CardContainer, StyledCard} from "./CardLayout";
+import P from '@splunk/react-ui/Paragraph';
+import styled from 'styled-components';
+import { variables } from '@splunk/themes';
+import PropTypes from 'prop-types';
+import { getIndicators, useGetRecord } from './ApiClient';
+import Loader from './Loader';
+import { viewIndicator } from './urls';
+import { CardContainer, StyledCard } from './CardLayout';
 
 const StyledParagraph = styled(P)`
     font-size: ${variables.fontSize};
 `;
 
-export function IndicatorCard({indicatorId}) {
-    const {loading, record, error} = useGetRecord({
-        restGetFunction: getIndicator,
-        restFunctionQueryArgs: {indicatorId},
-    });
-    const cardTitle = record ? `${record?.name}` : 'Indicator';
-    return <StyledCard to={viewIndicator(indicatorId)} title="Click for more info">
-        <Card.Header title={cardTitle}/>
-        <Card.Body>
-            <Loader loading={loading} error={error}>
-                <P>{record?.description}</P>
-                <code>{record?.stix_pattern}</code>
-            </Loader>
-        </Card.Body>
-    </StyledCard>
+export function IndicatorCard({ indicator_id, name, description, stix_pattern }) {
+    return (
+        <StyledCard to={viewIndicator(indicator_id)} title="Click for more info">
+            <Card.Header title={name ?? 'Indicator'} />
+            <Card.Body>
+                <P>{description}</P>
+                <code>{stix_pattern}</code>
+            </Card.Body>
+        </StyledCard>
+    );
 }
 
 IndicatorCard.propTypes = {
-    indicatorId: PropTypes.string.isRequired
+    indicator_id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    stix_pattern: PropTypes.string.isRequired,
+};
+
+function LayoutForIndicatorsExist({ indicators }) {
+    return (
+        <>
+            <StyledParagraph>Up to first 10 indicators shown</StyledParagraph>
+            {indicators.map((indicator) => (
+                <IndicatorCard
+                    key={indicator.indicator_id}
+                    indicator_id={indicator.indicator_id}
+                    name={indicator.name}
+                    description={indicator.description}
+                    stix_pattern={indicator.stix_pattern}
+                />
+            ))}
+        </>
+    );
 }
+LayoutForIndicatorsExist.propTypes = {
+    indicators: PropTypes.array.isRequired,
+};
 
-export function IndicatorCardLayout({indicatorIds}) {
-    if (indicatorIds.length === 0) {
-        return <StyledParagraph>No indicators</StyledParagraph>;
-    }
-    // TODO: Pass in groupingId as prop and perform a single request to GET list-indicators (getIndicators).
-    //  This would save on bandwidth, and scale better for groupings with 100+ indicators
-    return <CardContainer>
-        {indicatorIds.map(indicatorId => (
-            <IndicatorCard key={indicatorId} indicatorId={indicatorId}/>
-        ))}
-    </CardContainer>
-
+export function IndicatorCardLayout({ groupingId }) {
+    const {
+        loading,
+        record: response,
+        error,
+    } = useGetRecord({
+        restGetFunction: getIndicators,
+        restFunctionQueryArgs: {
+            limit: 10,
+            query: {
+                grouping_id: groupingId,
+            },
+        },
+    });
+    return (
+        <CardContainer>
+            <Loader loading={loading} error={error}>
+                {response?.records?.length > 0 ? (
+                    <LayoutForIndicatorsExist indicators={response?.records} />
+                ) : (
+                    <StyledParagraph>No indicators</StyledParagraph>
+                )}
+            </Loader>
+        </CardContainer>
+    );
 }
 
 IndicatorCardLayout.propTypes = {
-    indicatorIds: PropTypes.array.isRequired
-}
+    groupingId: PropTypes.string.isRequired,
+};

--- a/splunkui/packages/my-page/src/IndicatorCard.jsx
+++ b/splunkui/packages/my-page/src/IndicatorCard.jsx
@@ -38,6 +38,8 @@ export function IndicatorCardLayout({indicatorIds}) {
     if (indicatorIds.length === 0) {
         return <StyledParagraph>No indicators</StyledParagraph>;
     }
+    // TODO: Pass in groupingId as prop and perform a single request to GET list-indicators (getIndicators).
+    //  This would save on bandwidth, and scale better for groupings with 100+ indicators
     return <CardContainer>
         {indicatorIds.map(indicatorId => (
             <IndicatorCard key={indicatorId} indicatorId={indicatorId}/>

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/Styles.ts
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/Styles.ts
@@ -8,3 +8,12 @@ export const StyledContainer = styled.div`
     line-height: 200%;
     margin: ${variables.spacingXXLarge} ${variables.spacingXXLarge};
 `;
+
+export const ContentContainer = styled.div`
+    max-width: 800px;
+
+    & > * {
+        margin-top: 10px;
+        margin-bottom: 10px;
+    }
+`;

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
@@ -90,6 +90,7 @@ getUserTheme()
             <Component />,
             {
                 theme,
+                pageTitle: 'Internal Testing Tool',
             }
         );
     })

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
@@ -32,20 +32,16 @@ function generateCreateIndicatorsPayload(groupingId: String, n: Number = 10) {
     };
 }
 
+const createIndicatorsForGrouping = async (groupingId: String) => {
+    await postCreateIndicator(generateCreateIndicatorsPayload(groupingId, 10), (resp: Object) => {
+        console.log(resp);
+    });
+};
+
 function Component(){
     const [groupingId, setGroupingId] = useState<string>('');
     const handleTextChange = (e:any) => {
         setGroupingId(e.target.value);
-    }
-
-    async function handleButtonClick() {
-        console.log('button clicked');
-        await postCreateIndicator(
-            generateCreateIndicatorsPayload(groupingId),
-            (resp: Object) => {
-                console.log(resp);
-            },
-        );
     }
 
     return (
@@ -57,12 +53,21 @@ function Component(){
                 <ControlGroup label="Grouping ID">
                     <Text canClear value={groupingId} onChange={handleTextChange} />
                 </ControlGroup>
-                <ControlGroup label="Operations on grouping">
+                <Heading level={3}>Operations</Heading>
+                <ControlGroup label="Add indicators to grouping">
                     <Button
-                        label={`Add 10 indicators to grouping ${groupingId}`}
+                        label={`Add 10 indicators to grouping: ${groupingId}`}
                         disabled={!groupingId}
                         appearance="primary"
-                        onClick={handleButtonClick}
+                        onClick={() => createIndicatorsForGrouping(groupingId)}
+                    />
+                </ControlGroup>
+                <ControlGroup label="Purge indicators on grouping">
+                    <Button
+                        label={`Delete all indicators in grouping: ${groupingId}`}
+                        disabled={!groupingId}
+                        appearance="destructive"
+                        onClick={() => console.warn('TODO')}
                     />
                 </ControlGroup>
             </ContentContainer>

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import layout from '@splunk/react-page/18';
 import { getUserTheme } from '@splunk/splunk-utils/themes';
 import Button from '@splunk/react-ui/Button';
@@ -8,12 +8,44 @@ import Text from '@splunk/react-ui/Text';
 import Heading from '@splunk/react-ui/Heading';
 
 
-import { StyledContainer, ContentContainer } from './Styles';
+// @ts-ignore
+import { postCreateIndicator } from '@splunk/my-page/src/ApiClient.js';
+import { ContentContainer, StyledContainer } from './Styles';
+
+function generateCreateIndicatorsPayload(groupingId: String, n: Number = 10) {
+    const indicator = {
+        indicator_value: '111.122.133.144',
+        indicator_category: 'source_ipv4',
+        stix_pattern:
+            "[network-traffic:src_ref.type = 'ipv4-addr' AND network-traffic:src_ref.value = '111.122.133.144']",
+        name: 'ipv4',
+        description: 'ipv4',
+    };
+    // @ts-ignore
+    const indicators = Array.from({ length: n }, () => ({ ...indicator }));
+    return {
+        grouping_id: groupingId,
+        tlp_v2_rating: 'TLP:AMBER',
+        confidence: 50,
+        valid_from: '2026-06-17T04:37:37.000',
+        indicators,
+    };
+}
 
 function Component(){
     const [groupingId, setGroupingId] = useState<string>('');
     const handleTextChange = (e:any) => {
         setGroupingId(e.target.value);
+    }
+
+    async function handleButtonClick() {
+        console.log('button clicked');
+        await postCreateIndicator(
+            generateCreateIndicatorsPayload(groupingId),
+            (resp: Object) => {
+                console.log(resp);
+            },
+        );
     }
 
     return (
@@ -30,6 +62,7 @@ function Component(){
                         label={`Add 10 indicators to grouping ${groupingId}`}
                         disabled={!groupingId}
                         appearance="primary"
+                        onClick={handleButtonClick}
                     />
                 </ControlGroup>
             </ContentContainer>

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
@@ -9,10 +9,10 @@ import Heading from '@splunk/react-ui/Heading';
 
 
 // @ts-ignore
-import { postCreateIndicator } from '@splunk/my-page/src/ApiClient.js';
+import { postCreateIndicator, deleteIndicatorsInGrouping } from '@splunk/my-page/src/ApiClient.js';
 import { ContentContainer, StyledContainer } from './Styles';
 
-function generateCreateIndicatorsPayload(groupingId: String, n: Number = 10) {
+function generateCreateIndicatorsPayload(groupingId: String, n: Number = 100) {
     const indicator = {
         indicator_value: '111.122.133.144',
         indicator_category: 'source_ipv4',
@@ -33,10 +33,20 @@ function generateCreateIndicatorsPayload(groupingId: String, n: Number = 10) {
 }
 
 const createIndicatorsForGrouping = async (groupingId: String) => {
-    await postCreateIndicator(generateCreateIndicatorsPayload(groupingId, 10), (resp: Object) => {
+    await postCreateIndicator(generateCreateIndicatorsPayload(groupingId, 100), (resp: Object) => {
         console.log(resp);
     });
 };
+
+const handleOnClickDeleteIndicators = async(groupingId: String) => {
+    console.log(groupingId);
+    await deleteIndicatorsInGrouping({
+        groupingId,
+        successHandler: (resp:any) => {
+            console.log(resp);
+        }
+    })
+}
 
 function Component(){
     const [groupingId, setGroupingId] = useState<string>('');
@@ -56,7 +66,7 @@ function Component(){
                 <Heading level={3}>Operations</Heading>
                 <ControlGroup label="Add indicators to grouping">
                     <Button
-                        label={`Add 10 indicators to grouping: ${groupingId}`}
+                        label={`Add 100 indicators to grouping: ${groupingId}`}
                         disabled={!groupingId}
                         appearance="primary"
                         onClick={() => createIndicatorsForGrouping(groupingId)}
@@ -67,7 +77,7 @@ function Component(){
                         label={`Delete all indicators in grouping: ${groupingId}`}
                         disabled={!groupingId}
                         appearance="destructive"
-                        onClick={() => console.warn('TODO')}
+                        onClick={() => handleOnClickDeleteIndicators(groupingId)}
                     />
                 </ControlGroup>
             </ContentContainer>

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/MyPage/index.tsx
@@ -1,15 +1,45 @@
-import React from 'react';
+import React, {useState} from 'react';
 import layout from '@splunk/react-page/18';
-import MyPage from '@splunk/my-page';
 import { getUserTheme } from '@splunk/splunk-utils/themes';
-import { StyledContainer } from './Styles';
+import Button from '@splunk/react-ui/Button';
+import ControlGroup from '@splunk/react-ui/ControlGroup';
 
+import Text from '@splunk/react-ui/Text';
+import Heading from '@splunk/react-ui/Heading';
+
+
+import { StyledContainer, ContentContainer } from './Styles';
+
+function Component(){
+    const [groupingId, setGroupingId] = useState<string>('');
+    const handleTextChange = (e:any) => {
+        setGroupingId(e.target.value);
+    }
+
+    return (
+        <StyledContainer>
+            <ContentContainer>
+                <Heading level={1}>Internal Testing Tool</Heading>
+
+                <Heading level={2}>Grouping</Heading>
+                <ControlGroup label="Grouping ID">
+                    <Text canClear value={groupingId} onChange={handleTextChange} />
+                </ControlGroup>
+                <ControlGroup label="Operations on grouping">
+                    <Button
+                        label={`Add 10 indicators to grouping ${groupingId}`}
+                        disabled={!groupingId}
+                        appearance="primary"
+                    />
+                </ControlGroup>
+            </ContentContainer>
+        </StyledContainer>
+    );
+}
 getUserTheme()
     .then((theme) => {
         layout(
-            <StyledContainer>
-                <MyPage />
-            </StyledContainer>,
+            <Component />,
             {
                 theme,
             }

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/groupings/index.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/groupings/index.jsx
@@ -72,7 +72,7 @@ const expansionFieldNameToCellValue = {
     "Created At (UTC)": (row) => formatTimestampForDisplay(row.created),
     "Modified At (UTC)": (row) => formatTimestampForDisplay(row.modified),
     "Created By": (row) => <IdentityIdLink identityId={row.created_by_ref}/>,
-    "Indicators": (row) => <IndicatorCardLayout indicatorIds={row.indicators}/>,
+    "Indicators": (row) => <IndicatorCardLayout groupingId={row.grouping_id}/>,
     "Submissions": (row) => <SubmissionCardLayout groupingId={row.grouping_id}/>,
 }
 


### PR DESCRIPTION
Also update 'delete indicators' endpoint to support:
- delete by grouping_id
- indicator_id can be one or many (string or array)

The context for this relates to supporting #112, which may have a single grouping associate with 1000+ indicators.

Also an 'internal testing tool' page has been added which can be accessed via `https://<splunk-host>/en-GB/app/TA_CTIS_TAXII/MyPage`