### PR TITLE
Feature: Backend - STIX bundle can include sightings

### DIFF
--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -388,7 +388,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.27.0+d7c6a51",
+        "version": "1.28.0+5465926",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/package/bin/common.py
+++ b/TA_CTIS_TAXII/package/bin/common.py
@@ -220,6 +220,7 @@ class AbstractRestHandler(abc.ABC):
             query_params_dict = self.parse_query_params(in_string_dict["query"])
 
             self.kvstore_collections_context = KVStoreCollectionsContext(session_key=session_key, app_namespace=NAMESPACE)
+            # TODO: Set self.session_key? instead of passing it around
 
             payload = self.handle(input_json=input_json, query_params=query_params_dict, session_key=session_key)
             return {"payload": payload, "status": 200}

--- a/TA_CTIS_TAXII/package/bin/common.py
+++ b/TA_CTIS_TAXII/package/bin/common.py
@@ -13,7 +13,7 @@ from taxii2client.v21 import _TAXIIEndpoint
 
 from const import ADDON_NAME, ADDON_NAME_LOWER
 from models import SubmissionStatus, \
-    bundle_for_grouping, serialize_stix_object, maximum_tlpv2_of_indicators
+    bundle_for_grouping, serialize_stix_object, maximum_tlpv2_of_indicators, SightingModelV1
 from models.kvstore_collections import CollectionName, KVStoreCollectionsContext
 from server_exception import ServerException, RestResponseException
 from solnlib.log import Logs
@@ -122,7 +122,7 @@ class AbstractRestHandler(abc.ABC):
         bundle_json = None
         try:
             submission = self.kvstore_collections_context.submissions.get_submission(submission_id=submission_id)
-            bundle = self.generate_stix_bundle_for_grouping(grouping_id=submission.grouping_id)
+            bundle = self.generate_stix_bundle_for_grouping(grouping_id=submission.grouping_id, include_sightings=submission.include_sightings)
             bundle_json = serialize_stix_object(stix_object=bundle)
 
             taxii_config = self.get_taxii_config(session_key=session_key, stanza_name=submission.taxii_config_name)
@@ -242,19 +242,29 @@ class AbstractRestHandler(abc.ABC):
             logger.exception("Server error")
             return self.exception_response(e, 500)
 
-    def generate_stix_bundle_for_grouping(self, grouping_id:str) -> Bundle:
+    # TODO: Move into KVStoreCollectionsContext
+    def generate_stix_bundle_for_grouping(self, grouping_id:str, include_sightings: bool = False) -> Bundle:
         grouping = self.kvstore_collections_context.groupings.fetch_exactly_one_structured(query={"grouping_id": grouping_id})
         logger.info(f"grouping: {grouping}")
 
         indicators = self.kvstore_collections_context.indicators.fetch_many_by_grouping_id(grouping_id=grouping_id)
         logger.info(f"indicators: {indicators}")
 
-        identity = self.kvstore_collections_context.identities.fetch_exactly_one_structured(query={"identity_id" : grouping.created_by_ref})
-        logger.info(f"identity: {identity}")
+        sightings = []
+        if include_sightings:
+            for indicator in indicators:
+                more_sightings = self.kvstore_collections_context.sightings.fetch_many_by_sighting_of_ref(sighting_of_ref=indicator.indicator_id)
+                sightings.extend(more_sightings)
 
-        bundle = bundle_for_grouping(grouping_=grouping, indicators=indicators, grouping_identity=identity)
+        identity_ids_referenced_by_sightings = SightingModelV1.identity_ids_referenced_by_sightings(sightings=sightings)
+        all_identity_ids = identity_ids_referenced_by_sightings + [grouping.created_by_ref]
+        all_identities = self.kvstore_collections_context.identities.fetch_many_structured_by_primary_key(possible_values_of_primary_key=all_identity_ids)
+        logger.info(f"all_identities: {all_identities}")
+
+        bundle = bundle_for_grouping(grouping_=grouping, indicators=indicators, identities=all_identities, sightings=sightings)
         return bundle
 
+    # TODO: Move into KVStoreCollectionsContext
     def update_grouping_tlp_rating_to_match_indicators(self, grouping_id: str):
         indicators = self.kvstore_collections_context.indicators.fetch_many_by_grouping_id(grouping_id=grouping_id)
         logger.info(f"Grouping {grouping_id} has indicators: {indicators}")

--- a/TA_CTIS_TAXII/package/bin/models/__init__.py
+++ b/TA_CTIS_TAXII/package/bin/models/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pytz
 
@@ -44,16 +44,20 @@ def serialize_stix_object(stix_object: _STIXBase21, **kwargs) -> str:
 
     return serialized
 
-def bundle_for_grouping(grouping_: GroupingModelV1, grouping_identity: IdentityModelV1,
-                        indicators: List[IndicatorModelV1]) -> Bundle:
-    objects_to_gather_tlp_rating = indicators + [grouping_, grouping_identity]
-    unique_tlp_ratings = set([obj.tlp_v2_rating for obj in objects_to_gather_tlp_rating])
+def bundle_for_grouping(grouping_: GroupingModelV1, identities: List[IdentityModelV1],
+                        indicators: List[IndicatorModelV1], sightings: Optional[List[SightingModelV1]]=None) -> Bundle:
+    if sightings is None:
+        sightings = []
+    objects_to_gather_tlp_rating = indicators + sightings + identities + [grouping_]
+    unique_tlp_ratings = set([obj.tlp_v2_rating for obj in objects_to_gather_tlp_rating if obj.tlp_v2_rating is not None])
     object_marking_refs = [x.to_object_marking_ref() for x in unique_tlp_ratings]
 
-    indicators_as_stix = [ind.to_stix(created_by_ref=grouping_identity.identity_id) for ind in indicators]
+    indicators_as_stix = [ind.to_stix(created_by_ref=grouping_.created_by_ref) for ind in indicators]
 
-    grouping_object_ids = [ind.id for ind in indicators_as_stix] + [grouping_identity.identity_id]
+    grouping_object_ids = [ind.id for ind in indicators_as_stix] + [grouping_.created_by_ref]
     grouping_stix = grouping_.to_stix(object_ids=grouping_object_ids)
-    identity_stix = grouping_identity.to_stix()
-    objects = [grouping_stix, identity_stix] + indicators_as_stix + object_marking_refs
+
+    identities_as_stix = [_identity.to_stix() for _identity in identities]
+    sightings_as_stix = [s.to_stix() for s in sightings]
+    objects = [grouping_stix] + identities_as_stix + indicators_as_stix + sightings_as_stix + object_marking_refs
     return Bundle(objects=objects)

--- a/TA_CTIS_TAXII/package/bin/models/kvstore_collections/abstract_collection.py
+++ b/TA_CTIS_TAXII/package/bin/models/kvstore_collections/abstract_collection.py
@@ -17,10 +17,20 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+
 class AbstractKVStoreCollection(ABC, Generic[T]):
     def __init__(self, session_key: str, app_namespace: str):
         self.session_key = session_key
         self.app_namespace = app_namespace
+
+
+    @staticmethod
+    def query_or(operands: List[Dict]) -> Dict:
+        return {"$or": operands}
+
+    @staticmethod
+    def query_in(field: str, possible_values: List[str]) -> Dict:
+        return AbstractKVStoreCollection.query_or([{field: value} for value in possible_values])
 
     @property
     @abstractmethod
@@ -89,6 +99,10 @@ class AbstractKVStoreCollection(ABC, Generic[T]):
 
     def fetch_many_structured(self, query: dict) -> List[T]:
         return [self.model_converter.structure(record, self.model_class) for record in self.fetch_many_raw(query=query)]
+
+    def fetch_many_structured_by_primary_key(self, possible_values_of_primary_key: List) -> List[T]:
+        query = self.query_in(field=self.primary_key, possible_values=possible_values_of_primary_key)
+        return self.fetch_many_structured(query=query)
 
     def update_one_structured(self, query: Dict, updates: Dict) -> T:
         """

--- a/TA_CTIS_TAXII/package/bin/models/sighting.py
+++ b/TA_CTIS_TAXII/package/bin/models/sighting.py
@@ -89,6 +89,16 @@ class SightingModelV1(BaseModelV1):
             if self.first_seen > self.last_seen:
                 raise ValueError("first_seen must be <= last_seen")
 
+    @staticmethod
+    def identity_ids_referenced_by_sightings(sightings: List[SightingModelV1]):
+        identity_ids = set()
+        for sighting in sightings:
+            if sighting.created_by_ref is not None:
+                identity_ids.add(sighting.created_by_ref)
+            for sighting_of_ref in sighting.where_sighted_refs:
+                identity_ids.add(sighting_of_ref)
+        return list(identity_ids)
+
     def to_stix(self) -> StixSighting:
         kwargs = {
             "id": self.sighting_id,

--- a/TA_CTIS_TAXII/package/bin/models/submission.py
+++ b/TA_CTIS_TAXII/package/bin/models/submission.py
@@ -29,5 +29,6 @@ class SubmissionModelV1(BaseModelV1):
     collection_id: str = field()
     response_json: Optional[str] = field(default=None)
     error_message: Optional[str] = field(default=None)
+    include_sightings: bool = field(default=False)
 
 submission_converter = make_base_converter()

--- a/TA_CTIS_TAXII/package/bin/rest_get_stix_bundle_for_grouping.py
+++ b/TA_CTIS_TAXII/package/bin/rest_get_stix_bundle_for_grouping.py
@@ -13,7 +13,9 @@ class GetStixBundleForGroupingHandler(AbstractRestHandler):
 
         include_sightings = False
         if "include_sightings" in query_params:
-            include_sightings = True
+            query_params_include_sightings = query_params["include_sightings"][0]
+            if query_params_include_sightings == "1" or query_params_include_sightings.lower() == "true":
+                include_sightings = True
 
         bundle = self.generate_stix_bundle_for_grouping(grouping_id=grouping_id, include_sightings=include_sightings)
 

--- a/TA_CTIS_TAXII/package/bin/rest_get_stix_bundle_for_grouping.py
+++ b/TA_CTIS_TAXII/package/bin/rest_get_stix_bundle_for_grouping.py
@@ -10,7 +10,12 @@ class GetStixBundleForGroupingHandler(AbstractRestHandler):
         if "grouping_id" not in query_params:
             raise ValueError("grouping_id is required as query parameter.")
         grouping_id = query_params["grouping_id"][0]
-        bundle = self.generate_stix_bundle_for_grouping(grouping_id=grouping_id)
+
+        include_sightings = False
+        if "include_sightings" in query_params:
+            include_sightings = True
+
+        bundle = self.generate_stix_bundle_for_grouping(grouping_id=grouping_id, include_sightings=include_sightings)
 
         return {
             "bundle": json.loads(serialize_stix_object(stix_object=bundle))

--- a/TA_CTIS_TAXII/package/bin/rest_list_groupings.py
+++ b/TA_CTIS_TAXII/package/bin/rest_list_groupings.py
@@ -23,6 +23,7 @@ class ListGroupingsHandler(AbstractRestHandler):
         logger.info(f"grouping_ids: {grouping_ids}")
         indicators_collection = self.get_collection(collection_name="indicators", session_key=session_key)
 
+        # TODO: Replace with AbstractKVStoreCollection.fetch_many_structured_by_primary_key()
         indicators = []
         if grouping_ids:
             indicators_query = query_value_in_list("grouping_id", grouping_ids)

--- a/TA_CTIS_TAXII/package/bin/rest_submit_grouping.py
+++ b/TA_CTIS_TAXII/package/bin/rest_submit_grouping.py
@@ -41,7 +41,8 @@ class SubmitGroupingHandler(AbstractRestHandler):
         grouping_id = input_json["grouping_id"]
         taxii_config_name = input_json["taxii_config_name"]
         taxii_collection_id = input_json["taxii_collection_id"]
-        include_sightings = "include_sightings" in input_json
+        include_sightings = input_json.get("include_sightings", False)
+        assert isinstance(include_sightings, bool), "include_sightings must be a boolean value."
 
         # Validate that TAXII Config exists
         self.get_taxii_config(session_key=session_key, stanza_name=taxii_config_name)

--- a/TA_CTIS_TAXII/package/bin/rest_submit_grouping.py
+++ b/TA_CTIS_TAXII/package/bin/rest_submit_grouping.py
@@ -19,7 +19,7 @@ def validate_input_json(input_json: dict):
 
 
 class SubmitGroupingHandler(AbstractRestHandler):
-    def insert_submission_record(self, grouping_id: str, taxii_config_name: str, taxii_collection_id: str, scheduled_at: Optional[str] = None) -> Tuple[SubmissionModelV1, dict]:
+    def insert_submission_record(self, grouping_id: str, taxii_config_name: str, taxii_collection_id: str, scheduled_at: Optional[str] = None, include_sightings: bool = False) -> Tuple[SubmissionModelV1, dict]:
         scheduled_at_kwargs = {}
         if scheduled_at:
             scheduled_at_kwargs["scheduled_at"] = datetime.fromisoformat(scheduled_at)
@@ -30,6 +30,7 @@ class SubmitGroupingHandler(AbstractRestHandler):
             taxii_config_name=taxii_config_name,
             collection_id=taxii_collection_id,
             status=SubmissionStatus.SCHEDULED,
+            include_sightings=include_sightings,
             **scheduled_at_kwargs
         )
         unstructured = self.kvstore_collections_context.submissions.insert_record(record=new_submission)
@@ -40,17 +41,21 @@ class SubmitGroupingHandler(AbstractRestHandler):
         grouping_id = input_json["grouping_id"]
         taxii_config_name = input_json["taxii_config_name"]
         taxii_collection_id = input_json["taxii_collection_id"]
+        include_sightings = "include_sightings" in input_json
 
         # Validate that TAXII Config exists
         self.get_taxii_config(session_key=session_key, stanza_name=taxii_config_name)
 
         # Validates that the grouping exists, along with the indicators and identity objects
-        bundle = self.generate_stix_bundle_for_grouping(grouping_id=grouping_id)
+        bundle = self.generate_stix_bundle_for_grouping(grouping_id=grouping_id, include_sightings=include_sightings)
         logger.info(f"Validated bundle: {bundle.serialize()}")
 
         scheduled_at = input_json.get("scheduled_at")  # optional
-        structured, unstructured = self.insert_submission_record(grouping_id=grouping_id, taxii_config_name=taxii_config_name,
-                                                                taxii_collection_id=taxii_collection_id, scheduled_at=scheduled_at)
+        structured, unstructured = self.insert_submission_record(grouping_id=grouping_id,
+                                                                 taxii_config_name=taxii_config_name,
+                                                                 taxii_collection_id=taxii_collection_id,
+                                                                 scheduled_at=scheduled_at,
+                                                                 include_sightings=include_sightings)
         if scheduled_at:
             return {
                 "submission": unstructured

--- a/TA_CTIS_TAXII/test/test_bundle.py
+++ b/TA_CTIS_TAXII/test/test_bundle.py
@@ -1,69 +1,90 @@
 import json
 
-from TA_CTIS_TAXII.package.bin.models import GroupingModelV1, IdentityModelV1, bundle_for_grouping
+from TA_CTIS_TAXII.package.bin.models import GroupingModelV1, IdentityModelV1, SightingModelV1, bundle_for_grouping
 from TA_CTIS_TAXII.package.bin.models.tlp_v2 import AMBER_MARKING_DEFINITION, AMBER_STRICT_MARKING_DEFINITION, TLPv2, \
     GREEN_MARKING_DEFINITION, \
     RED_MARKING_DEFINITION
 from TA_CTIS_TAXII.package.bin.models import serialize_stix_object
 from test_model_indicator_v1 import new_sample_indicator_instance
 
+IDENTITY_1 = IdentityModelV1(name="Test Identity 1", identity_class="organization",
+                           tlp_v2_rating=TLPv2.AMBER_STRICT)
+IDENTITY_2 = IdentityModelV1(name="Test Identity 2", identity_class="organization", tlp_v2_rating=TLPv2.RED)
+GROUPING_1 = GroupingModelV1(name="Group ABC", description="Group ABC description", context="unspecified",
+                           created_by_ref=IDENTITY_1.identity_id, tlp_v2_rating=TLPv2.AMBER)
 
-class TestStixBundle:
-    def test_bundling_grouping_of_indicators(self):
-        identity = IdentityModelV1(name="Test Identity", identity_class="organization",
-                                   tlp_v2_rating=TLPv2.AMBER_STRICT)
-        grouping = GroupingModelV1(name="Group ABC", description="Group ABC description", context="unspecified",
-                                   created_by_ref=identity.identity_id, tlp_v2_rating=TLPv2.AMBER)
-        indicator1 = new_sample_indicator_instance()
-        indicator1.grouping_id = grouping.grouping_id
-        indicator1.stix_pattern = "[domain-name:value = 'malicious-domain.com']"
-        indicator1.tlp_v2_rating = TLPv2.RED
 
-        indicator2 = new_sample_indicator_instance()
-        indicator2.grouping_id = grouping.grouping_id
-        indicator2.stix_pattern = "[file:name = 'hello.exe']"
-        indicator2.tlp_v2_rating = TLPv2.GREEN
+def test_bundling_grouping_of_indicators():
+    indicator1 = new_sample_indicator_instance()
+    indicator1.grouping_id = GROUPING_1.grouping_id
+    indicator1.stix_pattern = "[domain-name:value = 'malicious-domain.com']"
+    indicator1.tlp_v2_rating = TLPv2.RED
 
-        indicator3 = new_sample_indicator_instance()
-        indicator3.grouping_id = grouping.grouping_id
-        indicator3.stix_pattern = "[network-traffic:dst_ref.type = 'ipv4-addr' AND network-traffic:dst_ref.value = '1.2.3.4']"
-        indicator3.tlp_v2_rating = TLPv2.GREEN
+    indicator2 = new_sample_indicator_instance()
+    indicator2.grouping_id = GROUPING_1.grouping_id
+    indicator2.stix_pattern = "[file:name = 'hello.exe']"
+    indicator2.tlp_v2_rating = TLPv2.GREEN
 
-        bundle = bundle_for_grouping(grouping_=grouping, grouping_identity=identity,
-                                     indicators=[indicator1, indicator2, indicator3])
-        bundle_json = json.loads(serialize_stix_object(stix_object=bundle))
-        assert bundle_json["type"] == "bundle"
+    indicator3 = new_sample_indicator_instance()
+    indicator3.grouping_id = GROUPING_1.grouping_id
+    indicator3.stix_pattern = "[network-traffic:dst_ref.type = 'ipv4-addr' AND network-traffic:dst_ref.value = '1.2.3.4']"
+    indicator3.tlp_v2_rating = TLPv2.GREEN
 
-        grouping_objects = [x for x in bundle_json["objects"] if x["type"] == "grouping"]
-        assert len(grouping_objects) == 1
-        grouping_object = grouping_objects[0]
-        assert grouping_object["created_by_ref"] == identity.identity_id
-        assert grouping_object["object_marking_refs"] == [AMBER_MARKING_DEFINITION.id]
-        assert set(grouping_object["object_refs"]) == {indicator1.indicator_id, indicator2.indicator_id,
-                                                       indicator3.indicator_id, identity.identity_id}
+    bundle = bundle_for_grouping(grouping_=GROUPING_1, identities=[IDENTITY_1],
+                                 indicators=[indicator1, indicator2, indicator3])
+    bundle_json = json.loads(serialize_stix_object(stix_object=bundle))
+    assert bundle_json["type"] == "bundle"
 
-        identity_objects = [x for x in bundle_json["objects"] if x["type"] == "identity"]
-        assert len(identity_objects) == 1
-        identity_object = identity_objects[0]
-        assert identity_object["id"] == identity.identity_id
-        assert identity_object["object_marking_refs"] == [AMBER_STRICT_MARKING_DEFINITION.id]
+    grouping_objects = [x for x in bundle_json["objects"] if x["type"] == "grouping"]
+    assert len(grouping_objects) == 1
+    grouping_object = grouping_objects[0]
+    assert grouping_object["created_by_ref"] == IDENTITY_1.identity_id
+    assert grouping_object["object_marking_refs"] == [AMBER_MARKING_DEFINITION.id]
+    assert set(grouping_object["object_refs"]) == {indicator1.indicator_id, indicator2.indicator_id,
+                                                   indicator3.indicator_id, IDENTITY_1.identity_id}
 
-        object_id_to_type = {x["id"]: x["type"] for x in bundle_json["objects"]}
+    identity_objects = [x for x in bundle_json["objects"] if x["type"] == "identity"]
+    assert len(identity_objects) == 1
+    identity_object = identity_objects[0]
+    assert identity_object["id"] == IDENTITY_1.identity_id
+    assert identity_object["object_marking_refs"] == [AMBER_STRICT_MARKING_DEFINITION.id]
 
-        assert object_id_to_type[grouping.grouping_id] == "grouping"
-        assert object_id_to_type[identity.identity_id] == "identity"
+    object_id_to_type = {x["id"]: x["type"] for x in bundle_json["objects"]}
 
-        assert object_id_to_type[indicator1.indicator_id] == "indicator"
-        assert object_id_to_type[indicator2.indicator_id] == "indicator"
-        assert object_id_to_type[indicator3.indicator_id] == "indicator"
+    assert object_id_to_type[GROUPING_1.grouping_id] == "grouping"
+    assert object_id_to_type[IDENTITY_1.identity_id] == "identity"
 
-        # Only unique TLP ratings should be added to the bundle
-        assert object_id_to_type[RED_MARKING_DEFINITION.id] == "marking-definition"
-        assert object_id_to_type[GREEN_MARKING_DEFINITION.id] == "marking-definition"
-        assert object_id_to_type[AMBER_MARKING_DEFINITION.id] == "marking-definition"
-        assert object_id_to_type[AMBER_STRICT_MARKING_DEFINITION.id] == "marking-definition"
+    assert object_id_to_type[indicator1.indicator_id] == "indicator"
+    assert object_id_to_type[indicator2.indicator_id] == "indicator"
+    assert object_id_to_type[indicator3.indicator_id] == "indicator"
 
-        indicator_id_to_indicator = {x["id"]: x for x in bundle_json["objects"] if x["type"] == "indicator"}
-        assert len(indicator_id_to_indicator) == 3
-        assert indicator_id_to_indicator[indicator1.indicator_id][
-                   "created_by_ref"] == identity.identity_id, "Indicator should have the grouping's identity as the creator"
+    # Only unique TLP ratings should be added to the bundle
+    assert object_id_to_type[RED_MARKING_DEFINITION.id] == "marking-definition"
+    assert object_id_to_type[GREEN_MARKING_DEFINITION.id] == "marking-definition"
+    assert object_id_to_type[AMBER_MARKING_DEFINITION.id] == "marking-definition"
+    assert object_id_to_type[AMBER_STRICT_MARKING_DEFINITION.id] == "marking-definition"
+
+    indicator_id_to_indicator = {x["id"]: x for x in bundle_json["objects"] if x["type"] == "indicator"}
+    assert len(indicator_id_to_indicator) == 3
+    assert indicator_id_to_indicator[indicator1.indicator_id][
+               "created_by_ref"] == IDENTITY_1.identity_id, "Indicator should have the grouping's identity as the creator"
+
+def test_bundle_including_sightings():
+    indicator1 = new_sample_indicator_instance()
+    indicator1.grouping_id = GROUPING_1.grouping_id
+    indicator1.stix_pattern = "[domain-name:value = 'malicious-domain.com']"
+    indicator1.tlp_v2_rating = TLPv2.RED
+
+    sighting1 = SightingModelV1(sighting_of_ref=indicator1.indicator_id, created_by_ref=IDENTITY_2.identity_id)
+
+    bundle_object = bundle_for_grouping(grouping_=GROUPING_1, identities=[IDENTITY_1, IDENTITY_2], indicators=[indicator1], sightings=[sighting1])
+    bundle_json = json.loads(serialize_stix_object(stix_object=bundle_object))
+
+    assert bundle_json["type"] == "bundle"
+
+    object_ids = [obj["id"] for obj in bundle_json["objects"]]
+    assert indicator1.indicator_id in object_ids
+    assert GROUPING_1.grouping_id in object_ids
+    assert sighting1.sighting_id in object_ids
+    assert IDENTITY_1.identity_id in object_ids
+    assert IDENTITY_2.identity_id in object_ids

--- a/TA_CTIS_TAXII/test/test_model_submission_v1.py
+++ b/TA_CTIS_TAXII/test/test_model_submission_v1.py
@@ -22,6 +22,7 @@ class TestSubmissionModel:
         assert as_dict["scheduled_at"] == "2024-01-02T03:04:05"
         assert as_dict["response_json"] is None
         assert as_dict["error_message"] is None
+        assert as_dict["include_sightings"] is False
 
     def test_unstructure_submission_now(self):
         submission = SubmissionModelV1(
@@ -44,6 +45,7 @@ class TestSubmissionModel:
         assert as_dict["taxii_config_name"] == "taxii_config"
         assert as_dict["collection_id"] == "abc123"
         assert "submission_id" in as_dict
+        assert as_dict["include_sightings"] is False
 
     def test_structure(self):
         as_dict = {
@@ -60,3 +62,32 @@ class TestSubmissionModel:
         assert submission.collection_id == "abc123"
         assert submission.submission_id is not None
         assert submission.grouping_id == GROUPING_ID
+        assert submission.include_sightings is False, "By default, include_sightings is False"
+
+class TestFieldIncludeSightings:
+    def test_structure_including_field(self):
+        as_dict = {
+            "grouping_id": GROUPING_ID,
+            "bundle_json_sent": "{}",
+            "status": "SCHEDULED",
+            "taxii_config_name": "taxii_config",
+            "collection_id": "abc123",
+            "include_sightings": True,
+        }
+        submission = submission_converter.structure(as_dict, SubmissionModelV1)
+        assert submission.include_sightings is True
+
+    def test_unstructure_including_field(self):
+        submission = SubmissionModelV1(
+            grouping_id=GROUPING_ID,
+            bundle_json_sent="{}",
+            status=SubmissionStatus.SCHEDULED,
+            taxii_config_name="taxii_config",
+            collection_id="abc123",
+            include_sightings=True,
+        )
+        assert submission.include_sightings is True
+        unstructured = submission_converter.unstructure(submission)
+        assert unstructured["grouping_id"] == GROUPING_ID
+        assert unstructured["include_sightings"] is True
+

--- a/integration_test/test_rest_api/test_submission_api.py
+++ b/integration_test/test_rest_api/test_submission_api.py
@@ -3,7 +3,9 @@ import logging
 import time
 from datetime import datetime, timedelta
 
-from util import list_submissions, post_submit_grouping_to_taxii_server, unschedule_submission, get_submission, get_grouping
+from util import (list_submissions, post_submit_grouping_to_taxii_server, unschedule_submission,
+                  get_submission, get_grouping, get_indicators_collection, create_new_sighting,
+                  example_sighting)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -68,7 +70,42 @@ class TestStixBundleSubmissionToTaxiiServer:
         assert last_submission_at > utc_now
 
     def test_immediate_submission_with_sightings(self, session, cleanup_all_collections, taxii_server_setup_and_grouping):
-        raise NotImplementedError
+        grouping_id = taxii_server_setup_and_grouping.grouping_id
+        ctis_app_taxii_config = taxii_server_setup_and_grouping.taxii_config_name
+        taxii2_server_details = taxii_server_setup_and_grouping.taxii2_server
+
+        # Retrieve the indicator created by the fixture
+        indicators = get_indicators_collection(session)
+        indicator = [ind for ind in indicators if ind.get("grouping_id") == grouping_id][0]
+        indicator_id = indicator["indicator_id"]
+        logger.info(f"Using indicator ID: {indicator_id}")
+
+        # Create a sighting for the indicator
+        sighting_payload = example_sighting(indicator_id=indicator_id, description="Test sighting for submission", count=1)
+        sighting_resp = create_new_sighting(session, payload=sighting_payload)
+        sighting_id = sighting_resp["sighting_id"]
+        logger.info(f"Created sighting: {sighting_resp}")
+
+        logger.info("Submitting bundle/grouping to TAXII server with sightings...")
+        submission_resp = post_submit_grouping_to_taxii_server(session=session,
+                                                               grouping_id=grouping_id,
+                                                               taxii_config_name=ctis_app_taxii_config,
+                                                               taxii_collection_id=taxii2_server_details.readable_and_writable_collection_id,
+                                                               include_sightings=True)
+        logger.info(f"Submission response: {submission_resp}")
+        submission_resp_obj = submission_resp["submission"]
+        assert submission_resp_obj["status"] == "SENT"
+        assert submission_resp_obj["grouping_id"] == grouping_id
+        assert submission_resp_obj["taxii_config_name"] == ctis_app_taxii_config
+
+        taxii_server_resp_json = submission_resp_obj["response_json"]
+        taxii_server_resp_obj = json.loads(taxii_server_resp_json)
+        assert taxii_server_resp_obj["status"] == "complete"
+
+        bundle_json_sent = json.loads(submission_resp_obj["bundle_json_sent"])
+        bundle_object_ids = [x["id"] for x in bundle_json_sent["objects"]]
+        assert sighting_id in bundle_object_ids
+
 
     def test_scheduled_submission(self, session, cleanup_all_collections, taxii_server_setup_and_grouping):
         grouping_id = taxii_server_setup_and_grouping.grouping_id

--- a/integration_test/test_rest_api/test_submission_api.py
+++ b/integration_test/test_rest_api/test_submission_api.py
@@ -1,19 +1,3 @@
-"""
-TODO:
-- Create fixture to spin up and tear down the TAXII server using the script provided.
-- Given Splunk host and credentials, and that the CTIS app is installed....
-- Create a new TAXII config in the app via a POST request:
-
-POST https://localhost:8089/servicesNS/-/TA_CTIS_TAXII/TA_CTIS_TAXII_taxii_config?output_mode=json
-Using x-www-form-urlencoded body with fields:
-name, api_root_url, username, password.
-
-- Create an identity
-- Create a grouping
-- Create an indicator which references the identity and grouping created
-- Get preview of STIX bundle JSON for grouping via API
-- Submit STIX bundle to TAXII server via API
-"""
 import json
 import logging
 import time
@@ -82,6 +66,9 @@ class TestStixBundleSubmissionToTaxiiServer:
         last_submission_at = get_grouping_last_submission_at(session=session, grouping_id=grouping_id)
         logger.info(f"Grouping last submission at: {last_submission_at}.")
         assert last_submission_at > utc_now
+
+    def test_immediate_submission_with_sightings(self, session, cleanup_all_collections, taxii_server_setup_and_grouping):
+        raise NotImplementedError
 
     def test_scheduled_submission(self, session, cleanup_all_collections, taxii_server_setup_and_grouping):
         grouping_id = taxii_server_setup_and_grouping.grouping_id

--- a/integration_test/test_rest_api/util.py
+++ b/integration_test/test_rest_api/util.py
@@ -280,14 +280,24 @@ def example_sighting(indicator_id: str, **kwargs) -> dict:
     base.update(kwargs)
     return base
 
-def get_stix_bundle_json_preview(session, grouping_id: str) -> dict:
-    return get_endpoint(endpoint="get-stix-bundle-for-grouping", session=session, grouping_id=grouping_id)
 
-def post_submit_grouping_to_taxii_server(session, grouping_id: str, taxii_config_name: str, taxii_collection_id: str, scheduled_at:str=None) -> dict:
+def get_stix_bundle_json_preview(session, grouping_id: str, include_sightings: bool = False) -> dict:
+    query_params = {
+        "grouping_id": grouping_id,
+    }
+    if include_sightings:
+        query_params["include_sightings"] = "1"
+
+    return get_endpoint(endpoint="get-stix-bundle-for-grouping", session=session, **query_params)
+
+
+def post_submit_grouping_to_taxii_server(session, grouping_id: str, taxii_config_name: str, taxii_collection_id: str,
+                                         scheduled_at: str = None, include_sightings: bool = False) -> dict:
     payload = {
         "grouping_id": grouping_id,
         "taxii_config_name": taxii_config_name,
-        "taxii_collection_id": taxii_collection_id
+        "taxii_collection_id": taxii_collection_id,
+        "include_sightings": include_sightings
     }
     if scheduled_at is not None:
         payload["scheduled_at"] = scheduled_at


### PR DESCRIPTION
Resolves #117 

The 2 bundle endpoints expose a flag as to whether to include sightings of any indicator included in the specified grouping, in the STIX Bundle generated:
- `GET get-stix-bundle-for-grouping`
  - Optional query_param of `include_sightings` set to `"true"` 
- `POST submit-grouping`
  - Optional JSON body field of `include_sightings` set to `true`

By default, `include_sightings` is assumed to be false and no sightings will be included in generated STIX Bundle.
This is to support existing app users (ACSC CTIS partners), as currently contribution of Sighting objects is not supported on the backend of their program.