### PR TITLE
feat: Advanced settings checkbox feature flag for "enable_sightings"

### DIFF
--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -214,6 +214,13 @@
                             },
                             "help": "Default TAXII configuration to use for submissions",
                             "field": "default_taxii_config"
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Enable Sightings Feature",
+                            "field": "enable_sightings",
+                            "defaultValue": false,
+                            "help": "Note: Not supported for ASD CTIS partners. Enable to allow users to create sightings of indicators. Sightings can be included in Bundle submissions to the TAXII server."
                         }
                     ],
                     "title": "Advanced Settings"
@@ -388,7 +395,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.28.0+5465926",
+        "version": "1.29.0+14ea738",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [


### PR DESCRIPTION
Resolves #118 
The scope of this is only change to UCC configuration which presents advance settings toggle to user.

<img width="753" height="583" alt="image" src="https://github.com/user-attachments/assets/80af51b5-971b-4200-94bb-06c7040fecee" />
