### PR TITLE
Feature: Submit grouping with sightings

### DIFF
--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -395,7 +395,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.30.0+23425a6",
+        "version": "1.30.0+4c8dc0b",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -220,7 +220,7 @@
                             "label": "Enable Sightings Feature",
                             "field": "enable_sightings",
                             "defaultValue": false,
-                            "help": "Note: Not supported for ASD CTIS partners. Enable to allow users to create sightings of indicators. Sightings can be included in Bundle submissions to the TAXII server."
+                            "help": "EXPERIMENTAL. Note: Not supported for ASD CTIS partners. Enable to allow users to create sightings of indicators. Sightings can be included in Bundle submissions to the TAXII server."
                         }
                     ],
                     "title": "Advanced Settings"
@@ -395,7 +395,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.30.0+52021ac",
+        "version": "1.30.0+23425a6",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -395,7 +395,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.30.0+4685d55",
+        "version": "1.30.0+52021ac",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -395,7 +395,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.30.0+e975aa1",
+        "version": "1.30.0+4709f06",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/TA_CTIS_TAXII/globalConfig.json
+++ b/TA_CTIS_TAXII/globalConfig.json
@@ -395,7 +395,7 @@
     "meta": {
         "name": "TA_CTIS_TAXII",
         "restRoot": "TA_CTIS_TAXII",
-        "version": "1.30.0+4709f06",
+        "version": "1.30.0+4685d55",
         "displayName": "CTIS TAXII App",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/splunkui/packages/my-page/src/ApiClient.js
+++ b/splunkui/packages/my-page/src/ApiClient.js
@@ -267,11 +267,12 @@ export function getAdvancedSettings({successHandler, errorHandler}) {
     })
 }
 
-export function getStixBundleForGrouping({groupingId, successHandler, errorHandler}) {
+export function getStixBundleForGrouping({groupingId, includeSightings = false, successHandler, errorHandler}) {
     return getData({
         endpoint: 'get-stix-bundle-for-grouping',
         queryParams: {
-            grouping_id: groupingId
+            grouping_id: groupingId,
+            include_sightings: includeSightings ? 'true' : 'false',
         },
         successHandler, errorHandler
     })
@@ -366,6 +367,7 @@ export function useGetRecord({restGetFunction, restFunctionQueryArgs}) {
 
     const debouncedQueryArgs = useDebounce(JSON.stringify(restFunctionQueryArgs), 100);
     useEffect(() => {
+        setLoading(true);
         restGetFunction({
             ...restFunctionQueryArgs,
             successHandler: (resp) => {
@@ -373,10 +375,10 @@ export function useGetRecord({restGetFunction, restFunctionQueryArgs}) {
                 setRecord(resp);
                 setLoading(false);
             },
-            errorHandler: async (error) => {
-                const errorText = await errorToText(error);
+            errorHandler: async (_error) => {
+                const errorText = await errorToText(_error);
                 setError(errorText);
-                console.error(errorText, error);
+                console.error(errorText, _error);
                 setLoading(false);
             }
         });

--- a/splunkui/packages/my-page/src/ApiClient.js
+++ b/splunkui/packages/my-page/src/ApiClient.js
@@ -367,9 +367,10 @@ export function useGetRecord({restGetFunction, restFunctionQueryArgs}) {
 
     const debouncedQueryArgs = useDebounce(JSON.stringify(restFunctionQueryArgs), 100);
     useEffect(() => {
+        const queryArgs = JSON.parse(debouncedQueryArgs);
         setLoading(true);
         restGetFunction({
-            ...restFunctionQueryArgs,
+            ...queryArgs,
             successHandler: (resp) => {
                 console.log("Response:", resp);
                 setRecord(resp);
@@ -382,7 +383,8 @@ export function useGetRecord({restGetFunction, restFunctionQueryArgs}) {
                 setLoading(false);
             }
         });
-    }, [debouncedQueryArgs]);
+        // TODO: return a cleanup function which cancels in-flight requests
+    }, [debouncedQueryArgs, restGetFunction]);
     return {record, loading, error};
 }
 

--- a/splunkui/packages/my-page/src/Loader.jsx
+++ b/splunkui/packages/my-page/src/Loader.jsx
@@ -12,10 +12,12 @@ const MessageContent = styled.div`
 `;
 
 function Loading({loadingText = "Loading..."}) {
-    return (<Heading>
-        {loadingText}
-        <WaitSpinner size="large"/>
-    </Heading>);
+    return (
+        <Heading>
+            <WaitSpinner size="large" />
+            <div>{loadingText}</div>
+        </Heading>
+    );
 }
 
 Loading.propTypes = {

--- a/splunkui/packages/my-splunk-app/src/main/webapp/common/queryParams.js
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/common/queryParams.js
@@ -2,3 +2,7 @@ export function getUrlQueryParams() {
     return new URLSearchParams(window.location.search);
 }
 
+export function shouldUseDebugMode(){
+    return getUrlQueryParams().get('debug') !== null;
+}
+

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/debugForm.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/debugForm.jsx
@@ -1,21 +1,34 @@
 import { useFormContext } from 'react-hook-form';
 import React from 'react';
+import Heading from '@splunk/react-ui/Heading';
+import PropTypes from 'prop-types';
 import { FIELD_SCHEDULED_AT } from './formFields';
 
-export function DebugForm() {
+export function DebugForm({advancedSettings}) {
     const { formState, getFieldState, watch } = useFormContext();
     const formData = watch();
     return (
         <>
             <section>
+                <Heading level={3}>Advanced Settings</Heading>
+                <code>{JSON.stringify(advancedSettings, null, 2)}</code>
+            </section>
+            <section>
+                <Heading level={3}>Form Data</Heading>
                 <code>{JSON.stringify(formData, null, 2)}</code>
             </section>
             <section>
+                <Heading level={3}>Form Errors</Heading>
                 <code>{JSON.stringify(formState.errors, null, 2)}</code>
             </section>
             <section>
+                <Heading level={3}>Debug One Field</Heading>
                 <code>{JSON.stringify(getFieldState(FIELD_SCHEDULED_AT), null, 2)}</code>
             </section>
         </>
     );
+}
+
+DebugForm.propTypes = {
+    advancedSettings: PropTypes.object.isRequired,
 }

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/form.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/form.jsx
@@ -160,7 +160,7 @@ export function Form({ groupingId }) {
                             Error: {JSON.stringify(submissionError)}
                         </Message>
                     )}
-                    {DEBUG && <DebugForm />}
+                    {DEBUG && <DebugForm advancedSettings={advancedSettings}/>}
                     <section>
                         <GroupingId fieldName={FIELD_GROUPING_ID} />
                         <TaxiiConfigField

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/form.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/form.jsx
@@ -30,6 +30,7 @@ import { useTaxiiCollectionsOptions } from './hooks/useTaxiiCollectionsOptions';
 import { useFormSubmission } from './hooks/useFormSubmission';
 import {
     FIELD_GROUPING_ID,
+    FIELD_INCLUDE_SIGHTINGS,
     FIELD_SCHEDULED_AT,
     FIELD_TAXII_COLLECTION_ID,
     FIELD_TAXII_CONFIG_NAME,
@@ -37,17 +38,14 @@ import {
 } from './formFields';
 import { useExtractFromTaxiiConfig } from './hooks/useExtractFromTaxiiConfig';
 import { DebugForm } from './debugForm';
+import { SwitchContainer } from './switchContainer';
+import { IncludeSightingsControlGroup } from './includeSightingsControlGroup';
 
 const StyledForm = styled.form`
     max-width: 1000px;
 `;
-const SwitchContainer = styled.div`
-    flex-grow: 0;
-    min-width: fit-content;
-    max-width: 30%;
-`;
 
-const DEBUG = false;
+const DEBUG = true;
 
 export function Form({ groupingId }) {
     const title = 'Submit Grouping';
@@ -60,28 +58,24 @@ export function Form({ groupingId }) {
             [FIELD_TAXII_COLLECTION_ID]: null,
             [FIELD_GROUPING_ID]: groupingId,
             [FIELD_SCHEDULED_AT]: null,
+            [FIELD_INCLUDE_SIGHTINGS]: false,
         },
     });
-    const {
-        watch,
-        register,
-        trigger,
-        handleSubmit,
-        formState,
-        setValue,
-        clearErrors,
-        setError,
-    } = methods;
+    const { watch, register, trigger, handleSubmit, formState, setValue, clearErrors, setError } =
+        methods;
 
     const { error, loading, bundleJsonString, advancedSettings, taxiiConfig } =
         useSubmissionFormData(groupingId);
 
+    const { defaultTaxiiConfigName, enableSightings } = advancedSettings;
     const formCollectionId = watch(FIELD_TAXII_COLLECTION_ID);
     const debouncedCollectionId = useDebounce(formCollectionId, 300);
 
     const [scheduledSubmission, setScheduledSubmission] = useState(false);
     useRegisterFormFields(register, scheduledSubmission);
     const submitButtonLabel = scheduledSubmission ? 'Schedule Submission' : 'Submit Now';
+
+    const [includeSightings, setIncludeSightings] = useState(false);
 
     const selectedTaxiiConfig = watch(FIELD_TAXII_CONFIG_NAME);
     const { selectedDefaultCollectionId, taxiiConfigOptions, shouldDiscoverTaxiiCollections } =
@@ -131,11 +125,14 @@ export function Form({ groupingId }) {
     }, [collectionValidationError, collectionValidationLoading, setError, clearErrors]);
 
     useEffect(() => {
-        const { defaultTaxiiConfigName } = advancedSettings;
         if (isString(defaultTaxiiConfigName) && defaultTaxiiConfigName !== '') {
             setValue(FIELD_TAXII_CONFIG_NAME, defaultTaxiiConfigName, { shouldValidate: true });
         }
-    }, [advancedSettings, setValue]);
+    }, [defaultTaxiiConfigName, setValue]);
+
+    useEffect(() => {
+        setValue(FIELD_INCLUDE_SIGHTINGS, includeSightings);
+    }, [includeSightings, setValue]);
 
     const submitButtonDisabled = useMemo(
         () =>
@@ -146,6 +143,8 @@ export function Form({ groupingId }) {
             submitSuccess,
         [submitSuccess, formState, collectionValidationLoading, collectionOptionsLoading],
     );
+
+    // TODO: Regenerate Bundle JSON Preview if includeSightings changes
 
     return (
         <FormProvider {...methods}>
@@ -160,7 +159,7 @@ export function Form({ groupingId }) {
                             Error: {JSON.stringify(submissionError)}
                         </Message>
                     )}
-                    {DEBUG && <DebugForm advancedSettings={advancedSettings}/>}
+                    {DEBUG && <DebugForm advancedSettings={advancedSettings} />}
                     <section>
                         <GroupingId fieldName={FIELD_GROUPING_ID} />
                         <TaxiiConfigField
@@ -204,6 +203,12 @@ export function Form({ groupingId }) {
                             </SwitchContainer>
                         </CustomControlGroup>
                         {scheduledSubmission && <ScheduledAt fieldName={FIELD_SCHEDULED_AT} />}
+                        {enableSightings && (
+                            <IncludeSightingsControlGroup
+                                handleOnClick={() => setIncludeSightings((v) => !v)}
+                                selected={includeSightings}
+                            />
+                        )}
                     </section>
                     <CustomControlGroup>
                         <HorizontalButtonLayout>

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/form.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/form.jsx
@@ -6,8 +6,6 @@ import styled from 'styled-components';
 import SubmitButton from '@splunk/my-page/src/SubmitButton';
 import { CustomControlGroup } from '@splunk/my-page/src/CustomControlGroup';
 import { HorizontalButtonLayout } from '@splunk/my-page/src/HorizontalButtonLayout';
-import CollapsiblePanel from '@splunk/react-ui/CollapsiblePanel';
-import Code from '@splunk/react-ui/Code';
 import Switch from '@splunk/react-ui/Switch';
 import { dateToIsoStringWithoutTimezone } from '@splunk/my-page/src/date_utils';
 import moment from 'moment';
@@ -40,12 +38,14 @@ import { useExtractFromTaxiiConfig } from './hooks/useExtractFromTaxiiConfig';
 import { DebugForm } from './debugForm';
 import { SwitchContainer } from './switchContainer';
 import { IncludeSightingsControlGroup } from './includeSightingsControlGroup';
+import { PreviewStixBundleJson } from './previewStixBundleJson';
+import { shouldUseDebugMode } from '../../common/queryParams';
 
 const StyledForm = styled.form`
     max-width: 1000px;
 `;
 
-const DEBUG = true;
+const DEBUG = shouldUseDebugMode();
 
 export function Form({ groupingId }) {
     const title = 'Submit Grouping';
@@ -64,8 +64,7 @@ export function Form({ groupingId }) {
     const { watch, register, trigger, handleSubmit, formState, setValue, clearErrors, setError } =
         methods;
 
-    const { error, loading, bundleJsonString, advancedSettings, taxiiConfig } =
-        useSubmissionFormData(groupingId);
+    const { error, loading, advancedSettings, taxiiConfig } = useSubmissionFormData(groupingId);
 
     const { defaultTaxiiConfigName, enableSightings } = advancedSettings;
     const formCollectionId = watch(FIELD_TAXII_COLLECTION_ID);
@@ -144,8 +143,6 @@ export function Form({ groupingId }) {
         [submitSuccess, formState, collectionValidationLoading, collectionOptionsLoading],
     );
 
-    // TODO: Regenerate Bundle JSON Preview if includeSightings changes
-
     return (
         <FormProvider {...methods}>
             <StyledForm name="SubmitGrouping" onSubmit={handleSubmit(onSubmit)}>
@@ -219,11 +216,10 @@ export function Form({ groupingId }) {
                             />
                         </HorizontalButtonLayout>
                     </CustomControlGroup>
-                    <section>
-                        <CollapsiblePanel title="Preview of STIX Bundle JSON">
-                            <Code language="json" value={bundleJsonString} />
-                        </CollapsiblePanel>
-                    </section>
+                    <PreviewStixBundleJson
+                        groupingId={groupingId}
+                        includeSightings={includeSightings}
+                    />
                 </Loader>
             </StyledForm>
         </FormProvider>

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/formFields.js
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/formFields.js
@@ -5,6 +5,7 @@ export const FIELD_TAXII_CONFIG_NAME = 'taxii_config_name';
 export const FIELD_TAXII_COLLECTION_ID = 'taxii_collection_id';
 export const FIELD_GROUPING_ID = 'grouping_id';
 export const FIELD_SCHEDULED_AT = 'scheduled_at';
+export const FIELD_INCLUDE_SIGHTINGS = 'include_sightings';
 
 export function useRegisterFormFields(register, isScheduledSubmission){
     useEffect(() => {
@@ -13,6 +14,7 @@ export function useRegisterFormFields(register, isScheduledSubmission){
         register(FIELD_TAXII_COLLECTION_ID, {
             required: 'TAXII Collection is required',
         });
+        register(FIELD_INCLUDE_SIGHTINGS, { required: false });
 
         if(isScheduledSubmission){
             register(FIELD_SCHEDULED_AT, { validate: validateScheduledAt });

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useAdvancedSettings.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useAdvancedSettings.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getAdvancedSettings, useGetRecord } from '@splunk/my-page/src/ApiClient';
+
+export function useAdvancedSettings() {
+    const [defaultTaxiiConfigName, setDefaultTaxiiConfigName] = useState('');
+    const [enableSightings, setEnableSightings] = useState(false);
+    const advancedSettings = useMemo(
+        () => ({
+            defaultTaxiiConfigName,
+            enableSightings
+        }),
+        [defaultTaxiiConfigName, enableSightings],
+    );
+    const { loading, record, error } = useGetRecord({
+        restGetFunction: getAdvancedSettings,
+        restFunctionQueryArgs: {},
+    });
+    useEffect(() => {
+        if (record !== null) {
+            setDefaultTaxiiConfigName(record.default_taxii_config ?? '');
+            setEnableSightings(record.enable_sightings === '1');
+        }
+    }, [record]);
+
+    return { loading, error, advancedSettings };
+}

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useStixBundlePreview.js
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useStixBundlePreview.js
@@ -1,0 +1,16 @@
+import { getStixBundleForGrouping, useGetRecord } from '@splunk/my-page/src/ApiClient';
+import { useEffect, useState } from 'react';
+
+export function useStixBundlePreview(groupingId, includeSightings = false) {
+    const [bundleJsonString, setBundleJsonString] = useState(null);
+    const { loading, record, error } = useGetRecord({
+        restGetFunction: getStixBundleForGrouping,
+        restFunctionQueryArgs: { groupingId, includeSightings },
+    });
+    useEffect(() => {
+        if (record?.bundle !== null) {
+            setBundleJsonString(JSON.stringify(record?.bundle, null, 4));
+        }
+    }, [record]);
+    return { loading, error, bundleJsonString };
+}

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useSubmissionFormData.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useSubmissionFormData.jsx
@@ -1,6 +1,5 @@
 import {
     getGrouping,
-    getStixBundleForGrouping,
     getTaxiiConfigs,
     useGetRecord,
 } from '@splunk/my-page/src/ApiClient';
@@ -23,24 +22,14 @@ export function useSubmissionFormData(groupingId) {
     });
 
     const {
-        loading: bundleLoading,
-        record: bundle,
-        error: bundleError,
-    } = useGetRecord({
-        restGetFunction: getStixBundleForGrouping,
-        restFunctionQueryArgs: { groupingId },
-    });
-    const bundleJsonString = JSON.stringify(bundle?.bundle, null, 4);
-
-    const {
         loading: loadingAdvancedSettings,
         error: errorAdvancedSettings,
         advancedSettings,
     } = useAdvancedSettings();
 
     const loading =
-        loadingGrouping || bundleLoading || loadingTaxiiConfigs || loadingAdvancedSettings;
-    const error = groupingError || bundleError || taxiiConfigError || errorAdvancedSettings;
+        loadingGrouping || loadingTaxiiConfigs || loadingAdvancedSettings;
+    const error = groupingError || taxiiConfigError || errorAdvancedSettings;
 
-    return { loading, error, taxiiConfig, bundleJsonString, advancedSettings };
+    return { loading, error, taxiiConfig, advancedSettings };
 }

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useSubmissionFormData.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/hooks/useSubmissionFormData.jsx
@@ -1,33 +1,10 @@
 import {
-    getAdvancedSettings,
     getGrouping,
     getStixBundleForGrouping,
     getTaxiiConfigs,
     useGetRecord,
 } from '@splunk/my-page/src/ApiClient';
-import { useEffect, useMemo, useState } from 'react';
-
-function useAdvancedSettings(){
-    const [defaultTaxiiConfigName, setDefaultTaxiiConfigName] = useState('');
-    const advancedSettings = useMemo(() => (
-        {
-            defaultTaxiiConfigName,
-        }
-    ), [defaultTaxiiConfigName])
-    const { loading, record, error } = useGetRecord({
-        restGetFunction: getAdvancedSettings,
-        restFunctionQueryArgs: {},
-    });
-    useEffect(() => {
-        if(record !== null){
-            setDefaultTaxiiConfigName(record.default_taxii_config ?? '')
-
-        }
-    }, [record]);
-
-
-    return {loading, error, advancedSettings};
-}
+import { useAdvancedSettings } from './useAdvancedSettings';
 
 export function useSubmissionFormData(groupingId) {
     // Validates groupingId, but does not use response
@@ -55,9 +32,11 @@ export function useSubmissionFormData(groupingId) {
     });
     const bundleJsonString = JSON.stringify(bundle?.bundle, null, 4);
 
-    const { loading: loadingAdvancedSettings, error: errorAdvancedSettings, advancedSettings } =
-        useAdvancedSettings();
-
+    const {
+        loading: loadingAdvancedSettings,
+        error: errorAdvancedSettings,
+        advancedSettings,
+    } = useAdvancedSettings();
 
     const loading =
         loadingGrouping || bundleLoading || loadingTaxiiConfigs || loadingAdvancedSettings;

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/includeSightingsControlGroup.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/includeSightingsControlGroup.jsx
@@ -1,0 +1,26 @@
+import { CustomControlGroup } from '@splunk/my-page/src/CustomControlGroup';
+import Switch from '@splunk/react-ui/Switch';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SwitchContainer } from './switchContainer';
+
+export function IncludeSightingsControlGroup({ selected, handleOnClick }) {
+    return (
+        <CustomControlGroup label="Include Sightings?">
+            <SwitchContainer>
+                <Switch
+                    key="switchIncludeSightings"
+                    onClick={handleOnClick}
+                    selected={selected}
+                    appearance="toggle"
+                >
+                    {selected ? 'Will include sightings' : 'Will exclude sightings'}
+                </Switch>
+            </SwitchContainer>
+        </CustomControlGroup>
+    );
+}
+IncludeSightingsControlGroup.propTypes = {
+    selected: PropTypes.bool,
+    handleOnClick: PropTypes.func,
+};

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/previewStixBundleJson.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/previewStixBundleJson.jsx
@@ -1,0 +1,24 @@
+import CollapsiblePanel from '@splunk/react-ui/CollapsiblePanel';
+import Loader from '@splunk/my-page/src/Loader';
+import Code from '@splunk/react-ui/Code';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useStixBundlePreview } from './hooks/useStixBundlePreview';
+
+export function PreviewStixBundleJson({ groupingId, includeSightings }) {
+    const { loading, error, bundleJsonString } = useStixBundlePreview(groupingId, includeSightings);
+
+    return (
+        <section>
+            <CollapsiblePanel title="Preview of STIX Bundle JSON">
+                <Loader error={error} loading={loading}>
+                    <Code language="json" value={bundleJsonString} />
+                </Loader>
+            </CollapsiblePanel>
+        </section>
+    );
+}
+PreviewStixBundleJson.propTypes = {
+    groupingId: PropTypes.string.isRequired,
+    includeSightings: PropTypes.bool.isRequired,
+};

--- a/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/switchContainer.jsx
+++ b/splunkui/packages/my-splunk-app/src/main/webapp/pages/submissions/switchContainer.jsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const SwitchContainer = styled.div`
+    flex-grow: 0;
+    min-width: fit-content;
+    max-width: 30%;
+`;


### PR DESCRIPTION
Related to #119 

Changes to Submit Grouping page.
New behaviour:
- If 'Enable Sightings Feature' is enabled in Advanced Settings, then an additional switch button for 'Include Sightings?' is shown. By default the switch is toggled off.
- If the switch button is toggled on, then the POST request to `submit-grouping` will include a boolean called `include_sightings` set to true.
- If the feature flag is disabled this switch is not shown and `include_sightings` will be false.

Example JSON payload for a request to submit a grouping including sightings:
```json
{"taxii_config_name":"docker_taxii","taxii_collection_id":"365fed99-08fa-fdcd-a1b3-fb247eb41d01","grouping_id":"grouping--1e4d6382-a18d-49fc-88d8-72e9dbe318b0","scheduled_at":null,"include_sightings":true}
```

<img width="1206" height="842" alt="image" src="https://github.com/user-attachments/assets/d773a1fa-69d5-420a-b469-6b891dfac79d" />
